### PR TITLE
Fix response status code in logs

### DIFF
--- a/ngsi_adapter/README.rst
+++ b/ngsi_adapter/README.rst
@@ -9,7 +9,7 @@ attributes, and forward them through a NGSI Context Broker.
 Installation
 ============
 
-Adapter is distributed as a Debian (.deb) package. Assuming FI WARE package
+Adapter is distributed as a Debian (.deb) package. Assuming FIWARE package
 repositories are configured, just use the proper tool (such as ``apt-get``)
 to install ``fiware-monitoring-ngsi-adapter`` package. These distributions are
 currently supported:
@@ -87,6 +87,10 @@ an object *EntityData*.
 Changelog
 =========
 
+Version 1.2.1
+
+-  Minor bugs resolved
+
 Version 1.2.0
 
 -  Add new log format (issue #25)
@@ -112,4 +116,4 @@ Version 1.0.0
 License
 =======
 
-\(c) 2013-2014 Telefónica I+D, Apache License 2.0
+\(c) 2013-2015 Telefónica I+D, Apache License 2.0

--- a/ngsi_adapter/script/build/files/debian/changelog
+++ b/ngsi_adapter/script/build/files/debian/changelog
@@ -1,3 +1,9 @@
+fiware-monitoring-ngsi-adapter (1.2.1) precise; urgency=low
+
+  * Minor bugs resolved
+
+ -- Telefónica I+D <opensource@tid.es>  Mon, 12 Jan 2015 18:30:00 +0200
+
 fiware-monitoring-ngsi-adapter (1.2.0) precise; urgency=low
 
   * Included new log format (issue #25)

--- a/ngsi_adapter/src/lib/adapter.js
+++ b/ngsi_adapter/src/lib/adapter.js
@@ -165,7 +165,7 @@ function asyncRequestListener(request, response) {
                 logger.error(err.message);
             }
         }
-        logger.info('Response status %d %s', response.statusCode, http.STATUS_CODES[response.statusCode]);
+        logger.info('Response status %d %s', status, http.STATUS_CODES[status]);
         response.writeHead(status);
         response.end();
     });


### PR DESCRIPTION
#### Reviewers
@jframos 

#### Description
Log message has been modified to show the right status code.

#### Testing
Logged status has been verified in all cases: 200 (OK), 404 (Not found) and 405 (Not allowed, e.g. GET method)
