### PR TITLE
Neutron supported in quantum-related parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ For more information, please refer to the description of Monitoring GE in
 
 ## Releases
 
+[FIWARE 3.5.2 (R6)][release_3_5_2_ref]
+
+* ngsi_event_broker version 1.3.2
+* ngsi_adapter version 1.1.5
+
 [FIWARE 3.5.2 (R5)][release_3_5_2_ref]
 
 * ngsi_event_broker version 1.3.2
@@ -55,7 +60,7 @@ For more information, please refer to the description of Monitoring GE in
 
 ## License
 
-(c) 2013-2014 Telefónica I+D, Apache License 2.0
+(c) 2013-2015 Telefónica I+D, Apache License 2.0
 
 [fiware_catalogue_monitoring_ref]:
 http://catalogue.fiware.org/enablers/monitoring-ge-fiware-implementation

--- a/ngsi_adapter/README.md
+++ b/ngsi_adapter/README.md
@@ -69,6 +69,10 @@ two components: probe data and optional performance data.
 
 ## Changelog
 
+Version 1.1.5
+
+* Neutron supported in quantum-related parsers
+
 Version 1.1.4
 
 * Add more attributes to region.js parser (required by ODC 2.4)

--- a/ngsi_adapter/script/build/files/debian/changelog
+++ b/ngsi_adapter/script/build/files/debian/changelog
@@ -1,3 +1,9 @@
+fiware-monitoring-ngsi-adapter (1.1.5) precise; urgency=low
+
+  * Neutron supported in quantum-related parsers
+
+ -- Telefónica I+D <opensource@tid.es>  Thu, 14 May 2015 15:00:00 +0200
+
 fiware-monitoring-ngsi-adapter (1.1.4) precise; urgency=low
 
   * Added more attributes to region.js parser (required by ODC 2.4)

--- a/ngsi_adapter/script/build/files/redhat/SPECS/fiware-monitoring-ngsi-adapter.spec
+++ b/ngsi_adapter/script/build/files/redhat/SPECS/fiware-monitoring-ngsi-adapter.spec
@@ -189,6 +189,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Thu May 14 2015 Telefónica I+D <opensource@tid.es> 1.1.5-1
+- Neutron supported in quantum-related parsers
+
 * Thu May 07 2015 Telefónica I+D <opensource@tid.es> 1.1.4-1
 - Add more attributes to region.js parser (required by ODC 2.4)
 

--- a/ngsi_adapter/src/lib/parsers/check_neutron_server.js
+++ b/ngsi_adapter/src/lib/parsers/check_neutron_server.js
@@ -8,6 +8,7 @@ var nagios = require('./common/nagios');
 
 // Information about the status of the service quantum-server
 // PROCS OK: 4 processes with command name 'neutron-server'|(null)
+// DEPRECATED: use 'check_quantum_server.js' instead
 var parser = Object.create(nagios.parser);
 parser.getContextAttrs = function(probeEntityData) {
     var data  = probeEntityData.data.split('\n')[0];

--- a/ngsi_adapter/src/lib/parsers/check_quantum_dhcp_agent.js
+++ b/ngsi_adapter/src/lib/parsers/check_quantum_dhcp_agent.js
@@ -11,21 +11,20 @@ var nagios = require('./common/nagios');
 var parser = Object.create(nagios.parser);
 parser.getContextAttrs = function(probeEntityData) {
     var data  = probeEntityData.data.split('\n')[0];
-    var attrs = { quantum_dhcp_agent: 0};
+    var attrs = { quantum_dhcp_agent: 0 };
     var items = data.split(':');
-    if ((items.length)>0 ) {
-	if (items[1].indexOf("quantum-dhcp-agent") != -1){
-		if(items[0].indexOf("PROCS OK") !=-1){
-			attrs.quantum_dhcp_agent=1
-		}
-		else{
-	        	attrs.quantum_dhcp_agent=0
-		}
-	}
-    }
-    else{
+    if (items.length > 0) {
+        if (items[1].match(/(quantum|neutron)-dhcp-agent/)) {
+            if (items[0].indexOf("PROCS OK") != -1) {
+                attrs.quantum_dhcp_agent = 1;
+            } else {
+                attrs.quantum_dhcp_agent = 0;
+            }
+        }
+    } else {
         throw new Error('No valid quantum-dhcp-agent data found');
     }
     return attrs;
 };
+
 exports.parser = parser;

--- a/ngsi_adapter/src/lib/parsers/check_quantum_l3_agent.js
+++ b/ngsi_adapter/src/lib/parsers/check_quantum_l3_agent.js
@@ -11,21 +11,20 @@ var nagios = require('./common/nagios');
 var parser = Object.create(nagios.parser);
 parser.getContextAttrs = function(probeEntityData) {
     var data  = probeEntityData.data.split('\n')[0];
-    var attrs = { quantum_l3_agent: 0};
+    var attrs = { quantum_l3_agent: 0 };
     var items = data.split(':');
-    if ((items.length)>0 ) {
-	if (items[1].indexOf("quantum-l3-agent") != -1){
-		if(items[0].indexOf("PROCS OK") !=-1){
-			attrs.quantum_l3_agent=1
-		}
-		else{
-	        	attrs.quantum_l3_agent=0
-		}
-	}
-    }
-    else{
+    if (items.length > 0) {
+        if (items[1].match(/(quantum|neutron)-l3-agent/)) {
+            if (items[0].indexOf("PROCS OK") != -1) {
+                attrs.quantum_l3_agent = 1;
+            } else {
+                attrs.quantum_l3_agent = 0;
+            }
+        }
+    } else {
         throw new Error('No valid quantum-l3-agent data found');
     }
     return attrs;
 };
+
 exports.parser = parser;

--- a/ngsi_adapter/src/lib/parsers/check_quantum_metadata_agent.js
+++ b/ngsi_adapter/src/lib/parsers/check_quantum_metadata_agent.js
@@ -11,21 +11,20 @@ var nagios = require('./common/nagios');
 var parser = Object.create(nagios.parser);
 parser.getContextAttrs = function(probeEntityData) {
     var data  = probeEntityData.data.split('\n')[0];
-    var attrs = { quantum_metadata_agent: 0};
+    var attrs = { quantum_metadata_agent: 0 };
     var items = data.split(':');
-    if ((items.length)>0 ) {
-	if (items[1].indexOf("quantum-metadata-agent") != -1){
-		if(items[0].indexOf("PROCS OK") !=-1){
-			attrs.quantum_metadata_agent=1
-		}
-		else{
-	        	attrs.quantum_metadata_agent=0
-		}
-	}
-    }
-    else{
+    if (items.length > 0) {
+        if (items[1].match(/(quantum|neutron)-metadata-agent/)) {
+            if (items[0].indexOf("PROCS OK") != -1) {
+                attrs.quantum_metadata_agent = 1;
+            } else {
+                attrs.quantum_metadata_agent = 0;
+            }
+        }
+    } else {
         throw new Error('No valid quantum-metadata-agent data found');
     }
     return attrs;
 };
+
 exports.parser = parser;

--- a/ngsi_adapter/src/lib/parsers/check_quantum_server.js
+++ b/ngsi_adapter/src/lib/parsers/check_quantum_server.js
@@ -11,21 +11,20 @@ var nagios = require('./common/nagios');
 var parser = Object.create(nagios.parser);
 parser.getContextAttrs = function(probeEntityData) {
     var data  = probeEntityData.data.split('\n')[0];
-    var attrs = { quantum_server: 0};
+    var attrs = { quantum_server: 0 };
     var items = data.split(':');
-    if ((items.length)>0 ) {
-	if (items[1].indexOf("quantum-server") != -1){
-		if(items[0].indexOf("PROCS OK") !=-1){
-			attrs.quantum_server=1
-		}
-		else{
-	        	attrs.quantum_server=0
-		}
-	}
-    }
-    else{
-        throw new Error('No valid quantum-server data found..');
+    if (items.length > 0) {
+        if (items[1].match(/(quantum|neutron)-server/)) {
+            if (items[0].indexOf("PROCS OK") != -1) {
+                attrs.quantum_server = 1;
+            } else {
+                attrs.quantum_server = 0;
+            }
+        }
+    } else {
+        throw new Error('No valid quantum-server data found');
     }
     return attrs;
 };
+
 exports.parser = parser;

--- a/ngsi_adapter/src/package.json
+++ b/ngsi_adapter/src/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "name": "ngsi_adapter",
   "main": "lib/adapter.js",
   "description": "Generic NGSI Probe Adapter",


### PR DESCRIPTION
#### Reviewers
@flopezag @attybro

#### Description
Existing quantum-related parsers now support Neutron processes being monitored.

#### Testing
Verified for Spain2 node.