### PR TITLE
Add UDP requests support

### DIFF
--- a/.bumpversion.sh
+++ b/.bumpversion.sh
@@ -46,7 +46,7 @@ which bumpversion >/dev/null || {
 }
 
 # Ask for new FIWARE release
-CUR_RELEASE=4.4.2
+CUR_RELEASE=5.1.2
 PROMPT="Please specify new FIWARE release (current is $CUR_RELEASE): "
 read -p "$PROMPT" NEW_RELEASE
 test -n "$(expr "$NEW_RELEASE" : '\([0-9]\+\.[0-9]\+\.[0-9]\+\)$')" || {

--- a/ContributionPolicy.txt
+++ b/ContributionPolicy.txt
@@ -6,8 +6,8 @@ and Telefónica I+D, contributors must send this policy signed in order to
 express the acceptance of all its sections.
 Contributor Contact Information
 Name (Contributor):__________________________________________________
-E-mail:_____________________________________________________________
-Phone:_____________________________________________________________
+E-mail:______________________________________________________________
+Phone:_______________________________________________________________
 Mailing Address:_____________________________________________________
 
 1. Contributor declare to own all the rights necessary to contribute with any
@@ -18,27 +18,28 @@ Telefónica I+D after the acceptance of this policy by Telefónica I+D.
 the  ownership of the Contribution in all worldwide common law and statutory
 rights associated with the copyrights, copyright application, copyright
 registration and moral rights in the Contribution to the extent allowable under
- applicable local laws and copyright conventions.
+applicable local laws and copyright conventions.
 
 3. The Contributor will keep the moral rights and the authorship of the
-Contribution,
+Contribution.
 
 4. The contributor agrees that the contribution given by this joint copyright
- assignment can be used by Telefónica I+D to establish and create privative
- versions of the contribution or to include it in privative products. The
- contributor will be mandatory mentioned as the author of the contribution,
- but all the rights and revenues of this privative version, will be owned by
- Telefónica I+D.
+assignment can be used by Telefónica I+D to establish and create privative
+versions of the contribution or to include it in privative products. The
+contributor will be mandatory mentioned as the author of the contribution,
+but all the rights and revenues of this privative version, will be owned by
+Telefónica I+D.
 
 5. This policy supersedes and replaces all prior copyrights assignments or
 agreements made by the contributor to Telefónica I+D under this project.
 
 6. This policy will apply to all contributions of the contributor, until one of
-the parties cancel or modify it by a written declaration or if a new one is signed.
+the parties cancel or modify it by a written declaration or if a new one is
+signed.
 
 7. Contributor is legally entitled to grant the above policy and agrees not to
 provide any Contribution that violates any law or breaches any contract.
 
-Signed: ____________________________________________Date:________________
+Signed:____________________________________________Date:________________
 
 Please send a signed original to opensource at tid dot es

--- a/README.rst
+++ b/README.rst
@@ -213,6 +213,8 @@ The configuration used by the adapter service is optionally read from the file
     # ADAPTER_LISTEN_PORT - The port where NGSI Adapter listens to requests
     ADAPTER_LISTEN_PORT=1337
 
+    # ADAPTER_UDP_ENDPOINTS - UDP listen endpoints (host:port:parser,...)
+
     # ADAPTER_BROKER_URL - The endpoint where Context Broker is listening
     ADAPTER_BROKER_URL=http://127.0.0.1:1026/
 
@@ -226,10 +228,11 @@ Most of these attributes map to options of the `command line interface
 - ``ADAPTER_LOGLEVEL`` maps to ``-l`` or ``--logLevel`` option
 - ``ADAPTER_LISTEN_HOST`` maps to ``-H`` or ``--listenHost`` option
 - ``ADAPTER_LISTEN_PORT`` maps to ``-p`` or ``--listenPort`` option
+- ``ADAPTER_UDP_ENDPOINTS`` maps to ``-u`` or ``--udpEndpoints`` option
 - ``ADAPTER_BROKER_URL`` maps to ``-b`` or ``--brokerUrl`` option
 - ``ADAPTER_RETRIES`` maps to ``-r`` or ``--retries`` option
 
-Default values are found in ``/opt/fiware/ngsi_adapter/config/options.js``.
+Default values are found in ``/opt/fiware/ngsi_adapter/lib/common.js``.
 
 
 Checking status

--- a/doc/manuals/admin/README.rst
+++ b/doc/manuals/admin/README.rst
@@ -165,6 +165,8 @@ You can use these command line options (available typing ``adapter --help``):
    The hostname or address at which NGSI Adapter listens
 -p, --listenPort
    The port number at which NGSI Adapter listens
+-u, --udpEndpoints
+   Optional list of UDP endpoints (host:port:parser)
 -b, --brokerUrl
    The URL of the Context Broker instance to publish data to
 -r, --retries
@@ -232,6 +234,9 @@ Network interfaces Up & Open
 
 NGSI Adapter uses TCP 1337 as default port, although it can be changed using
 the ``--listenPort`` command line option.
+
+Additionally, a list of UDP listen ports may be specified by ``--udpEndpoints``
+command line option.
 
 
 Databases

--- a/ngsi_adapter/README.rst
+++ b/ngsi_adapter/README.rst
@@ -22,6 +22,10 @@ Please refer to `this document </README.rst#running>`_ for details.
 Changelog
 =========
 
+Version 1.3.0
+
+- Add support to UDP requests
+
 Version 1.2.4
 
 - Add service configuration file

--- a/ngsi_adapter/script/build/files/debian/changelog
+++ b/ngsi_adapter/script/build/files/debian/changelog
@@ -1,3 +1,9 @@
+fiware-monitoring-ngsi-adapter (1.3.0) precise; urgency=low
+
+  * Add support to UDP requests
+
+ -- Telefónica I+D <opensource@tid.es>  Wed, 11 Nov 2015 18:00:00 +0200
+
 fiware-monitoring-ngsi-adapter (1.2.4) precise; urgency=low
 
   * Add service configuration file

--- a/ngsi_adapter/script/build/files/debian/ngsi_adapter.default
+++ b/ngsi_adapter/script/build/files/debian/ngsi_adapter.default
@@ -10,6 +10,8 @@ ADAPTER_LISTEN_HOST=0.0.0.0
 # ADAPTER_LISTEN_PORT - The port where NGSI Adapter listens to requests
 ADAPTER_LISTEN_PORT=1337
 
+# ADAPTER_UDP_ENDPOINTS - UDP listen endpoints (host:port:parser,...)
+
 # ADAPTER_BROKER_URL - The endpoint where Context Broker is listening
 ADAPTER_BROKER_URL=http://127.0.0.1:1026/
 

--- a/ngsi_adapter/script/build/files/redhat/SOURCES/etc/sysconfig/ngsi_adapter
+++ b/ngsi_adapter/script/build/files/redhat/SOURCES/etc/sysconfig/ngsi_adapter
@@ -10,6 +10,8 @@ ADAPTER_LISTEN_HOST=0.0.0.0
 # ADAPTER_LISTEN_PORT - The port where NGSI Adapter listens to requests
 ADAPTER_LISTEN_PORT=1337
 
+# ADAPTER_UDP_ENDPOINTS - UDP listen endpoints (host:port:parser,...)
+
 # ADAPTER_BROKER_URL - The endpoint where Context Broker is listening
 ADAPTER_BROKER_URL=http://127.0.0.1:1026/
 

--- a/ngsi_adapter/script/build/files/redhat/SPECS/fiware-monitoring-ngsi-adapter.spec
+++ b/ngsi_adapter/script/build/files/redhat/SPECS/fiware-monitoring-ngsi-adapter.spec
@@ -187,6 +187,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Wed Nov 11 2015 Telefónica I+D <opensource@tid.es> 1.3.0-1
+- Add support to UDP requests
+
 * Fri Aug 14 2015 Telefónica I+D <opensource@tid.es> 1.2.4-1
 - Add service configuration file
 

--- a/ngsi_adapter/src/.gjslintrc
+++ b/ngsi_adapter/src/.gjslintrc
@@ -5,5 +5,5 @@
 --nomultiprocess
 --debug_indentation
 --time
---disable=110,212,217
+--disable=1,110,212,217
 --custom_jsdoc_tags=module,function,callback,abstract,constant,augments,memberof,returns

--- a/ngsi_adapter/src/.gjslintrc
+++ b/ngsi_adapter/src/.gjslintrc
@@ -6,4 +6,4 @@
 --debug_indentation
 --time
 --disable=1,110,212,217
---custom_jsdoc_tags=module,function,callback,abstract,constant,augments,memberof,returns
+--custom_jsdoc_tags=module,namespace,property,function,callback,abstract,constant,augments,memberof,returns

--- a/ngsi_adapter/src/Gruntfile.js
+++ b/ngsi_adapter/src/Gruntfile.js
@@ -175,7 +175,7 @@ module.exports = function(grunt) {
                     quiet: true,
                     root: '<%= dirs.lib[0] %>',
                     coverageFolder: '<%= dirs.reportCoverage[0] %>',
-                    reportFormats: ['cobertura']
+                    reportFormats: ['lcovonly', 'cobertura']
                 }
             }
         },

--- a/ngsi_adapter/src/Gruntfile.js
+++ b/ngsi_adapter/src/Gruntfile.js
@@ -1,4 +1,6 @@
 'use strict';
+/* jshint -W106 */
+
 
 /**
  * Grunt tasks definitions
@@ -142,7 +144,6 @@ module.exports = function(grunt) {
                     ui: 'tdd',
                     reporter: 'xunit-file',
                     quiet: true
-
                 },
                 src: [
                     '<%= jshint.test.src %>'
@@ -150,34 +151,34 @@ module.exports = function(grunt) {
             }
         },
 
-		mocha_istanbul: {
-		    coverage: {
+        mocha_istanbul: {
+            coverage: {
                 src: '<%= dirs.test[0] %>',
                 options: {
-					root: '<%= dirs.lib[0] %>',
-					coverageFolder: '<%= dirs.reportCoverage[0] %>',
+                    root: '<%= dirs.lib[0] %>',
+                    coverageFolder: '<%= dirs.reportCoverage[0] %>',
                     reportFormats: ['lcovonly']
                 }
             },
-		    coverageHtml: {
+            coverageHtml: {
                 src: '<%= dirs.test[0] %>',
                 options: {
                     quiet: true,
-					root: '<%= dirs.lib[0] %>',
-					coverageFolder: '<%= dirs.siteCoverage[0] %>',
+                    root: '<%= dirs.lib[0] %>',
+                    coverageFolder: '<%= dirs.siteCoverage[0] %>',
                     reportFormats: ['lcov']
                 }
             },
-		    coberturaReport: {
+            coberturaReport: {
                 src: '<%= dirs.test[0] %>',
                 options: {
                     quiet: true,
-					root: '<%= dirs.lib[0] %>',
-					coverageFolder: '<%= dirs.reportCoverage[0] %>',
+                    root: '<%= dirs.lib[0] %>',
+                    coverageFolder: '<%= dirs.reportCoverage[0] %>',
                     reportFormats: ['cobertura']
                 }
             }
-		},
+        },
 
         dox: {
             options: {
@@ -249,13 +250,13 @@ module.exports = function(grunt) {
     grunt.registerTask('test-report', 'Generate tests reports',
         ['env', 'clean:reportTest', 'mkdir:reportTest', 'mochaTest:unitReport']);
 
-	grunt.registerTask('coverage', 'Print coverage summary',
+    grunt.registerTask('coverage', 'Print coverage summary',
         ['mocha_istanbul:coverage']);
 
-	grunt.registerTask('coverage-report', 'Generate Cobertura report',
+    grunt.registerTask('coverage-report', 'Generate Cobertura report',
         ['mocha_istanbul:coberturaReport']);
 
-	grunt.registerTask('coverage-html', 'Generate HTML site with coverage',
+    grunt.registerTask('coverage-html', 'Generate HTML site with coverage',
         ['mocha_istanbul:coverageHtml']);
 
     grunt.registerTask('complexity', 'Generate code complexity reports',

--- a/ngsi_adapter/src/config/options.js
+++ b/ngsi_adapter/src/config/options.js
@@ -26,22 +26,7 @@
 'use strict';
 
 
-/**
- * @namespace
- * @property {Object} defaults              Default values for configuration options.
- * @property {String} defaults.logLevel     Default logging level.
- * @property {String} defaults.brokerUrl    Default Context Broker URL.
- * @property {String} defaults.listenHost   Default adapter listen host.
- * @property {Number} defaults.listenPort   Default adapter listen port.
- * @property {Number} defaults.retries      Default maximum number of invocation retries.
- */
-var defaults = {
-    logLevel: 'INFO',
-    brokerUrl: 'http://127.0.0.1:1026/',
-    listenHost: '0.0.0.0',
-    listenPort: 1337,
-    retries: 2
-};
+var defaults = require('../lib/common').defaults;
 
 
 /**
@@ -49,9 +34,10 @@ var defaults = {
  * @property {Object} opts                  Command line options.
  * @property {String} opts.logLevel         Logging level.
  * @property {String} opts.brokerUrl        Context Broker URL.
- * @property {String} opts.listenHost       Adapter listen host.
- * @property {Number} opts.listenPort       Adapter listen port.
- * @property {Number} opts.retries          Maximum number of invocation retries.
+ * @property {String} opts.listenHost       Adapter listen HTTP host.
+ * @property {Number} opts.listenPort       Adapter listen HTTP port.
+ * @property {String} opts.udpEndpoints     Comma-separated list of UDP endpoints (host:port:parser).
+ * @property {Number} opts.retries          Maximum number of Context Broker invocation retries.
  */
 var opts = require('optimist')
     .options('l', {
@@ -66,6 +52,10 @@ var opts = require('optimist')
         alias: 'listenPort',
         'default': process.env['ADAPTER_LISTEN_PORT'] || defaults.listenPort,
         describe: 'Adapter listen port'
+    }).options('u', {
+        alias: 'udpEndpoints',
+        'default': process.env['ADAPTER_UDP_ENDPOINTS'] || defaults.udpEndpoints,
+        describe: 'List of UDP endpoints (host:port:parser)'
     }).options('b', {
         alias: 'brokerUrl',
         'default': process.env['ADAPTER_BROKER_URL'] || defaults.brokerUrl,

--- a/ngsi_adapter/src/lib/adapter.js
+++ b/ngsi_adapter/src/lib/adapter.js
@@ -222,17 +222,17 @@ function udpRequestListener(socket, message, parserName) {
  * Server main.
  */
 function main() {
-    process.on('uncaughtException', function (err) {
+    process.once('uncaughtException', function (err) {
         logger.error({op: 'Exit'}, err.message);
         process.exit(1);
     });
-    process.on('exit', function () {
+    process.once('exit', function () {
         logger.info({op: 'Exit'}, 'Server stopped');
     });
-    process.on('SIGINT', function () {
+    process.once('SIGINT', function () {
         process.exit();
     });
-    process.on('SIGTERM', function () {
+    process.once('SIGTERM', function () {
         process.exit();
     });
 

--- a/ngsi_adapter/src/lib/common.js
+++ b/ngsi_adapter/src/lib/common.js
@@ -30,3 +30,25 @@
  * HTTP header for transaction id.
  */
 exports.txIdHttpHeader = 'txId';
+
+
+/**
+ * Default values.
+ *
+ * @namespace
+ * @property {Object} defaults              Default values for configuration options.
+ * @property {String} defaults.logLevel     Default logging level.
+ * @property {String} defaults.brokerUrl    Default Context Broker URL.
+ * @property {String} defaults.listenHost   Default adapter HTTP listen host.
+ * @property {Number} defaults.listenPort   Default adapter HTTP listen port.
+ * @property {String} defaults.udpEndpoints Default list of UDP endpoints (host:port:parser).
+ * @property {Number} defaults.retries      Default maximum number of Context Broker invocation retries.
+ */
+exports.defaults = {
+    logLevel: 'INFO',
+    brokerUrl: 'http://127.0.0.1:1026/',
+    listenHost: '0.0.0.0',
+    listenPort: 1337,
+    udpEndpoints: null,
+    retries: 2
+};

--- a/ngsi_adapter/src/lib/parsers/common/base.js
+++ b/ngsi_adapter/src/lib/parsers/common/base.js
@@ -74,6 +74,8 @@ baseParser.updateContextRequest = function (reqdomain) {
 
     if (Object.keys(entityAttrs).length === 0) {
         throw new Error('Missing entity context attributes');
+    } else if (!entityId || !entityType) {
+        throw new Error('Missing entityId and/or entityType');
     }
 
     // feature #4: automatically add request timestamp to entity attributes

--- a/ngsi_adapter/src/lib/parsers/common/base.js
+++ b/ngsi_adapter/src/lib/parsers/common/base.js
@@ -67,10 +67,10 @@ baseParser.getContentType = function () {
  * @returns {String} The request body, either in XML or JSON format.
  */
 baseParser.updateContextRequest = function (reqdomain) {
-    var entityId = reqdomain.entityId,
-        entityType = reqdomain.entityType,
-        entityData = this.parseRequest(reqdomain.body),
-        entityAttrs = this.getContextAttrs(entityData);
+    var entityData = this.parseRequest(reqdomain),
+        entityAttrs = this.getContextAttrs(entityData),
+        entityId = reqdomain.entityId,
+        entityType = reqdomain.entityType;
 
     if (Object.keys(entityAttrs).length === 0) {
         throw new Error('Missing entity context attributes');
@@ -86,15 +86,15 @@ baseParser.updateContextRequest = function (reqdomain) {
 
 
 /**
- * Parses the request to extract raw probe data.
+ * Parses the request message body to extract raw probe data, and optionally sets `entityId` and `entityType`.
  *
  * @abstract
  * @function parseRequest
  * @memberof baseParser
- * @param {String} requestMsg  The data message included in request being processed.
+ * @param {Domain} reqdomain   Domain handling current request (includes context, timestamp, id, type, body & parser).
  * @returns {EntityData} An object holding entity data taken from request message.
  */
-baseParser.parseRequest = function (requestMsg) {
+baseParser.parseRequest = function (reqdomain) {
     throw new Error('Must implement');
 };
 

--- a/ngsi_adapter/src/lib/parsers/common/factory.js
+++ b/ngsi_adapter/src/lib/parsers/common/factory.js
@@ -67,6 +67,12 @@ function getParser(request) {
 
 
 /**
- * Parser factory.
+ * Parser factory: lookup by name.
+ */
+exports.getParserByName = getParserByName;
+
+
+/**
+ * Parser factory: lookup by request URL.
  */
 exports.getParser = getParser;

--- a/ngsi_adapter/src/lib/parsers/common/nagios.js
+++ b/ngsi_adapter/src/lib/parsers/common/nagios.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Telefónica I+D
+ * Copyright 2013-2015 Telefónica I+D
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -42,13 +42,13 @@ var nagiosParser = Object.create(baseParser);
  * Parses the request to extract raw probe data. Both data and optional performance
  * data are extracted from request body.
  *
- * @function paserRequest
+ * @function parseRequest
  * @memberof nagiosParser
- * @param {http.IncomingMessage} request    The HTTP request to this server.
+ * @param {String} requestMsg  The data message included in request being processed.
  * @returns {EntityData} An object with `data` (and optional `perfData`) members.
  *
  * Probe output format: <code>
- *         TEXT OUTPUT | OPTIONAL PERFDATA
+ *         TEXT OUTPUT DATA | OPTIONAL PERFDATA
  *         LONG TEXT LINE 1
  *         LONG TEXT LINE 2
  *         ...
@@ -58,9 +58,9 @@ var nagiosParser = Object.create(baseParser);
  *         PERFDATA LINE N
  * </code>
  */
-nagiosParser.parseRequest = function(request) {
+nagiosParser.parseRequest = function (requestMsg) {
     var entityData = {};
-    var lines = request.body.split('\n');
+    var lines = requestMsg.split('\n');
     var isMultilinePerf = false;
     lines.forEach(function(item) {
         var isFirst = !entityData.data;

--- a/ngsi_adapter/src/lib/parsers/common/nagios.js
+++ b/ngsi_adapter/src/lib/parsers/common/nagios.js
@@ -39,12 +39,11 @@ var nagiosParser = Object.create(baseParser);
 
 
 /**
- * Parses the request to extract raw probe data. Both data and optional performance
- * data are extracted from request body.
+ * Parses the request message body to extract Nagios probe data (both data and optional performance data).
  *
  * @function parseRequest
  * @memberof nagiosParser
- * @param {String} requestMsg  The data message included in request being processed.
+ * @param {Domain} reqdomain   Domain handling current request (includes context, timestamp, id, type, body & parser).
  * @returns {EntityData} An object with `data` (and optional `perfData`) members.
  *
  * Probe output format: <code>
@@ -58,9 +57,9 @@ var nagiosParser = Object.create(baseParser);
  *         PERFDATA LINE N
  * </code>
  */
-nagiosParser.parseRequest = function (requestMsg) {
+nagiosParser.parseRequest = function (reqdomain) {
     var entityData = {};
-    var lines = requestMsg.split('\n');
+    var lines = reqdomain.body.split('\n');
     var isMultilinePerf = false;
     lines.forEach(function(item) {
         var isFirst = !entityData.data;

--- a/ngsi_adapter/src/package.json
+++ b/ngsi_adapter/src/package.json
@@ -46,6 +46,8 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-mocha-test": "~0.7.0",
+    "grunt-mocha-istanbul": "~3.0.1",
+    "load-grunt-tasks": "~3.3.0",
     "xunit-file": "~0.0.5",
     "chai": "~1.8.0",
     "sinon": "~1.7.3",

--- a/ngsi_adapter/src/package.json
+++ b/ngsi_adapter/src/package.json
@@ -1,11 +1,11 @@
 {
-  "version": "1.2.4",
+  "version": "1.3.0",
   "name": "ngsi_adapter",
   "description": "Generic NGSI Probe Adapter",
   "product": {
     "name": "fiware-monitoring",
     "area": "iotplatform",
-    "release": "4.4.2"
+    "release": "5.1.2"
   },
   "keywords": [
     "FIWARE",

--- a/ngsi_adapter/src/package.json
+++ b/ngsi_adapter/src/package.json
@@ -52,7 +52,7 @@
     "chai": "~1.8.0",
     "sinon": "~1.7.3",
     "sinon-chai": "2.4.0",
-    "istanbul": "~0.1.34",
+    "istanbul": "~0.4.0",
     "proxyquire": "0.5.1",
     "dev-null": "0.1.1"
   }

--- a/ngsi_adapter/src/test/unit/test_adapter.js
+++ b/ngsi_adapter/src/test/unit/test_adapter.js
@@ -24,6 +24,7 @@
 
 
 'use strict';
+/* jshint -W069 */
 
 
 /** Fake command line arguments (required to load `adapter` without complaining) */
@@ -42,18 +43,18 @@ var http = require('http'),
 
 
 /* jshint multistr: true */
-suite('adapter', function() {
+suite('adapter', function () {
 
-    suiteSetup(function() {
+    suiteSetup(function () {
         var self = this;
         self.baseurl = 'http://hostname:1234';
         self.resource = 'check_load';
         self.body = 'invalid load data';
         self.headers = {};
-        sinon.stub(http, 'createServer', function() {
+        sinon.stub(http, 'createServer', function () {
             self.listener = arguments[0];
             return {
-                listen: function(port, host, callback) {
+                listen: function (port, host, callback) {
                     this.address = sinon.stub().returns({ address: host, port: port });
                     callback.call(this);
                 }
@@ -63,23 +64,22 @@ suite('adapter', function() {
         logger.setLevel('DEBUG');
     });
 
-    suiteTeardown(function() {
+    suiteTeardown(function () {
         http.createServer.restore();
     });
 
-    setup(function() {
+    setup(function () {
         adapter.main();
         this.request = new Emitter();
-        this.request.timestamp = Date.now();
         this.request.headers = this.headers;
         this.request.method = 'POST';
     });
 
-    teardown(function() {
+    teardown(function () {
         delete this.request;
     });
 
-    test('request_fails_if_not_post_method', function() {
+    test('request_fails_if_not_post_method', function () {
         var self = this;
         var response = {
             writeHead: sinon.stub(),
@@ -92,7 +92,7 @@ suite('adapter', function() {
         assert.equal(response.writeHead.args[0][0], 405);  // not allowed
     });
 
-    test('request_fails_missing_entity_id', function() {
+    test('request_fails_missing_entity_id', function () {
         var self = this;
         var response = {
             writeHead: sinon.stub(),
@@ -104,7 +104,7 @@ suite('adapter', function() {
         assert.equal(response.writeHead.args[0][0], 400);  // bad request
     });
 
-    test('request_fails_missing_entity_type', function() {
+    test('request_fails_missing_entity_type', function () {
         var self = this;
         var response = {
             writeHead: sinon.stub(),
@@ -116,7 +116,7 @@ suite('adapter', function() {
         assert.equal(response.writeHead.args[0][0], 400);  // bad request
     });
 
-    test('request_fails_unknown_url_resource', function() {
+    test('request_fails_unknown_url_resource', function () {
         var self = this;
         var response = {
             writeHead: sinon.stub(),
@@ -128,7 +128,7 @@ suite('adapter', function() {
         assert.equal(response.writeHead.args[0][0], 404);  // not found
     });
 
-    test('request_ok_valid_url_resource', function() {
+    test('request_ok_valid_url_resource', function () {
         var self = this;
         var response = {
             writeHead: sinon.stub(),
@@ -140,15 +140,15 @@ suite('adapter', function() {
         assert.equal(response.writeHead.args[0][0], 200);  // ok
     });
 
-    test('request_asynchronous_callback_error_on_invalid_resource_data', function(done) {
+    test('request_asynchronous_callback_error_on_invalid_resource_data', function (done) {
         var self = this;
         var response = {
             writeHead: sinon.stub(),
             end: sinon.stub()
         };
-        var callback = (function() {
-            var original = adapter.requestCallback;
-            return sinon.stub(adapter, 'requestCallback', function() {
+        var callback = (function () {
+            var original = adapter['updateContextCallback'];
+            return sinon.stub(adapter, 'updateContextCallback', function () {
                 original.apply(null, arguments);
                 callback.restore();
                 assert(callback.calledOnce);
@@ -164,25 +164,25 @@ suite('adapter', function() {
         self.request.emit('end');
     });
 
-    test('request_asynchronous_callback_error_after_all_retries', function(done) {
+    test('request_asynchronous_callback_error_after_all_retries', function (done) {
         var self = this;
         var response = {
             writeHead: sinon.stub(),
             end: sinon.stub()
         };
-        var factoryGetParser = sinon.stub(factory, 'getParser', function() {
+        var factoryGetParser = sinon.stub(factory, 'getParser', function () {
             var mockParser = Object.create(parser);
             mockParser.updateContextRequest = sinon.stub().returns('');
             return mockParser;
         });
-        var httpRequest = sinon.stub(http, 'request', function() {
+        var httpRequest = sinon.stub(http, 'request', function () {
             var clientRequest = new Emitter();
-            clientRequest.end = function() { this.emit('error', new Error()); };
+            clientRequest.end = function () { this.emit('error', new Error()); };
             return clientRequest;
         });
-        var callback = (function() {
-            var original = adapter.requestCallback;
-            return sinon.stub(adapter, 'requestCallback', function() {
+        var callback = (function () {
+            var original = adapter['updateContextCallback'];
+            return sinon.stub(adapter, 'updateContextCallback', function () {
                 original.apply(null, arguments);
                 callback.restore();
                 httpRequest.restore();
@@ -201,18 +201,18 @@ suite('adapter', function() {
         self.request.emit('end');
     });
 
-    test('request_asynchronous_callback_ok_with_valid_resource_data', function(done) {
+    test('request_asynchronous_callback_ok_with_valid_resource_data', function (done) {
         var self = this;
         var response = {
             writeHead: sinon.stub(),
             end: sinon.stub()
         };
-        var factoryGetParser = sinon.stub(factory, 'getParser', function() {
+        var factoryGetParser = sinon.stub(factory, 'getParser', function () {
             var mockParser = Object.create(parser);
             mockParser.updateContextRequest = sinon.stub().returns('');
             return mockParser;
         });
-        var httpRequest = sinon.stub(http, 'request', function(opts, callback) {
+        var httpRequest = sinon.stub(http, 'request', function (opts, callback) {
             var clientRequest = new Emitter();
             var serverResponse = new Emitter();
             serverResponse.setEncoding = sinon.stub();
@@ -223,9 +223,9 @@ suite('adapter', function() {
             clientRequest.end = sinon.stub();
             return clientRequest;
         });
-        var callback = (function() {
-            var original = adapter.requestCallback;
-            return sinon.stub(adapter, 'requestCallback', function() {
+        var callback = (function () {
+            var original = adapter['updateContextCallback'];
+            return sinon.stub(adapter, 'updateContextCallback', function () {
                 original.apply(null, arguments);
                 callback.restore();
                 httpRequest.restore();

--- a/ngsi_adapter/src/test/unit/test_adapter.js
+++ b/ngsi_adapter/src/test/unit/test_adapter.js
@@ -24,13 +24,6 @@
 
 
 'use strict';
-/* jshint -W069 */
-
-
-/** Constants to test UDP requests
-var UDP_PARSER = 'udp_parser',
-    UDP_HOST = 'localhost',
-    UDP_PORT = 1234;*/
 
 
 /** Fake command line arguments (required to load `adapter` without complaining) */
@@ -106,7 +99,6 @@ suite('adapter', function () {
     teardown(function () {
         delete this.request;
         this.udpServer.removeAllListeners();
-        process.removeAllListeners();
     });
 
     test('request_fails_if_not_post_method', function () {
@@ -177,7 +169,7 @@ suite('adapter', function () {
             end: sinon.stub()
         };
         var callback = (function () {
-            var original = adapter['updateContextCallback'];
+            var original = adapter.updateContextCallback;
             return sinon.stub(adapter, 'updateContextCallback', function () {
                 original.apply(null, arguments);
                 callback.restore();
@@ -211,7 +203,7 @@ suite('adapter', function () {
             return clientRequest;
         });
         var callback = (function () {
-            var original = adapter['updateContextCallback'];
+            var original = adapter.updateContextCallback;
             return sinon.stub(adapter, 'updateContextCallback', function () {
                 original.apply(null, arguments);
                 callback.restore();
@@ -254,7 +246,7 @@ suite('adapter', function () {
             return clientRequest;
         });
         var callback = (function () {
-            var original = adapter['updateContextCallback'];
+            var original = adapter.updateContextCallback;
             return sinon.stub(adapter, 'updateContextCallback', function () {
                 original.apply(null, arguments);
                 callback.restore();

--- a/ngsi_adapter/src/test/unit/test_base_parser.js
+++ b/ngsi_adapter/src/test/unit/test_base_parser.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Telefónica I+D
+ * Copyright 2013-2015 Telefónica I+D
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -33,9 +33,9 @@ var sinon = require('sinon'),
 
 
 /* jshint multistr: true */
-suite('base_parser', function() {
+suite('base_parser', function () {
 
-    suiteSetup(function() {
+    suiteSetup(function () {
         this.baseurl = 'http://hostname:1234/path';
         this.entityId = '1';
         this.entityType = 'host';
@@ -44,65 +44,71 @@ suite('base_parser', function() {
         };
     });
 
-    suiteTeardown(function() {
+    suiteTeardown(function () {
     });
 
-    setup(function() {
+    setup(function () {
         this.request = {
-            url: this.baseurl + '?id=' + this.entityId + '&type=' + this.entityType,
-            timestamp: Date.now()
+            url: this.baseurl + '?id=' + this.entityId + '&type=' + this.entityType
         };
-        this.entityData[parser.timestampAttrName] = this.request.timestamp;
+        this.reqdomain = {
+            timestamp: Date.now(),
+            entityId: this.entityId,
+            entityType: this.entityType
+        };
+        this.entityData[parser.timestampAttrName] = this.reqdomain.timestamp;
         this.parseRequestFunction = parser.parseRequest;
         this.getContextAttrsFunction = parser.getContextAttrs;
     });
 
-    teardown(function() {
+    teardown(function () {
         delete this.request;
+        delete this.reqdomain;
         delete this.entityData[parser.timestampAttrName];
         parser.parseRequest = this.parseRequestFunction;
         parser.getContextAttrs = this.getContextAttrsFunction;
     });
 
-    test('get_update_request_fails_unimplemented_method_parse_request', function() {
+    test('get_update_request_fails_unimplemented_method_parse_request', function () {
         var self = this;
+        parser.getContextAttrs = sinon.spy(function () { return {}; });
         assert.throws(
-            function() {
-                return parser.updateContextRequest(self.request);
+            function () {
+                return parser.updateContextRequest(self.reqdomain);
             },
             /implement/
         );
     });
 
-    test('get_update_request_fails_unimplemented_method_get_context_attrs', function() {
+    test('get_update_request_fails_unimplemented_method_get_context_attrs', function () {
         var self = this;
-        parser.parseRequest = sinon.spy(function() { return {}; });
+        parser.parseRequest = sinon.spy(function () { return {}; });
         assert.throws(
-            function() {
-                return parser.updateContextRequest(self.request);
+            function () {
+                return parser.updateContextRequest(self.reqdomain);
             },
             /implement/
         );
     });
 
-    test('get_update_request_fails_missing_entity_attributes', function() {
+    test('get_update_request_fails_missing_entity_attributes', function () {
         var self = this;
-        parser.parseRequest = sinon.spy(function() { return {}; });
-        parser.getContextAttrs = sinon.spy(function() { return {}; });
+        parser.parseRequest = sinon.spy(function () { return {}; });
+        parser.getContextAttrs = sinon.spy(function () { return {}; });
         self.request.url = self.baseurl + '?id=id&type=type&another=another';
-        self.request.body = '';
+        self.reqdomain.body = '';
         assert.throws(
             function() {
-                return parser.updateContextRequest(self.request);
+                return parser.updateContextRequest(self.reqdomain);
             }
         );
     });
 
-    test('get_update_request_ok_with_timestamp_added', function() {
+    test('get_update_request_ok_with_timestamp_added', function () {
         var self = this;
-        parser.parseRequest = sinon.spy(function() { return {}; });
-        parser.getContextAttrs = sinon.spy(function() { return self.entityData; });
-        var update = parser.updateContextRequest(self.request);
+        parser.parseRequest = sinon.spy(function () { return {}; });
+        parser.getContextAttrs = sinon.spy(function () { return self.entityData; });
+        var update = parser.updateContextRequest(self.reqdomain);
         common.assertValidUpdateXML(update, self);
     });
 

--- a/ngsi_adapter/src/test/unit/test_check_disk.js
+++ b/ngsi_adapter/src/test/unit/test_check_disk.js
@@ -130,7 +130,7 @@ suite('check_disk', function () {
             this.probeBody.singleGroup.perf
         );
         var parser = this.factory.getParser(this.request);
-        var requestData = parser.parseRequest(this.reqdomain.body);
+        var requestData = parser.parseRequest(this.reqdomain);
         var contextData = parser.getContextAttrs(requestData);
         assert(contextData.freeSpacePct);
         assert.equal(contextData.freeSpacePct, this.entityData.freeSpacePct);

--- a/ngsi_adapter/src/test/unit/test_check_load.js
+++ b/ngsi_adapter/src/test/unit/test_check_load.js
@@ -101,7 +101,7 @@ suite('check_load', function () {
     test('parse_ok_cpu_load_percentage', function () {
         this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
-        var requestData = parser.parseRequest(this.reqdomain.body);
+        var requestData = parser.parseRequest(this.reqdomain);
         var contextData = parser.getContextAttrs(requestData);
         assert(contextData.cpuLoadPct);
         assert.equal(contextData.cpuLoadPct, this.entityData.cpuLoadPct);

--- a/ngsi_adapter/src/test/unit/test_check_load.js
+++ b/ngsi_adapter/src/test/unit/test_check_load.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Telefónica I+D
+ * Copyright 2013-2015 Telefónica I+D
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -32,9 +32,9 @@ var util = require('util'),
 
 
 /* jshint laxbreak: true */
-suite('check_load', function() {
+suite('check_load', function () {
 
-    suiteSetup(function() {
+    suiteSetup(function () {
         this.timestampName = require('../../lib/parsers/common/base').parser.timestampAttrName;
         this.factory = require('../../lib/parsers/common/factory');
 
@@ -50,6 +50,7 @@ suite('check_load', function() {
             load5: 2 * this.entityData.cpuLoadPct,
             load15: 5 * this.entityData.cpuLoadPct
         };
+
         this.probeBody = {
             data: util.format('OK - load average: %d, %d, %d',
                   this.probeData.load1, this.probeData.load5, this.probeData.load15),
@@ -58,44 +59,49 @@ suite('check_load', function() {
         };
     });
 
-    suiteTeardown(function() {
+    suiteTeardown(function () {
     });
 
-    setup(function() {
+    setup(function () {
         this.request = {
-            url: this.baseurl + '?id=' + this.entityId + '&type=' + this.entityType,
-            timestamp: Date.now()
+            url: this.baseurl + '?id=' + this.entityId + '&type=' + this.entityType
         };
-        this.entityData[this.timestampName] = this.request.timestamp;
+        this.reqdomain = {
+            timestamp: Date.now(),
+            entityId: this.entityId,
+            entityType: this.entityType
+        };
+        this.entityData[this.timestampName] = this.reqdomain.timestamp;
     });
 
-    teardown(function() {
+    teardown(function () {
         delete this.request;
+        delete this.reqdomain;
         delete this.entityData[this.timestampName];
     });
 
-    test('get_update_request_fails_with_invalid_check_load_content', function() {
-        this.request.body = 'XXX INVALID XXX';
+    test('get_update_request_fails_with_invalid_check_load_content', function () {
+        this.reqdomain.body = 'XXX INVALID XXX';
         var self = this;
         var parser = this.factory.getParser(self.request);
         assert.throws(
-            function() {
-                return parser.updateContextRequest(self.request);
+            function () {
+                return parser.updateContextRequest(self.reqdomain);
             }
         );
     });
 
-    test('get_update_request_ok_with_valid_check_load_content', function() {
-        this.request.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
+    test('get_update_request_ok_with_valid_check_load_content', function () {
+        this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
-        var update = parser.updateContextRequest(this.request);
+        var update = parser.updateContextRequest(this.reqdomain);
         common.assertValidUpdateXML(update, this);
     });
 
-    test('parse_ok_cpu_load_percentage', function() {
-        this.request.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
+    test('parse_ok_cpu_load_percentage', function () {
+        this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
-        var requestData = parser.parseRequest(this.request);
+        var requestData = parser.parseRequest(this.reqdomain.body);
         var contextData = parser.getContextAttrs(requestData);
         assert(contextData.cpuLoadPct);
         assert.equal(contextData.cpuLoadPct, this.entityData.cpuLoadPct);

--- a/ngsi_adapter/src/test/unit/test_check_mem.sh.js
+++ b/ngsi_adapter/src/test/unit/test_check_mem.sh.js
@@ -97,7 +97,7 @@ suite('check_mem.sh', function () {
     test('parse_ok_used_mem_percentage', function () {
         this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
-        var requestData = parser.parseRequest(this.reqdomain.body);
+        var requestData = parser.parseRequest(this.reqdomain);
         var contextData = parser.getContextAttrs(requestData);
         assert(contextData.usedMemPct);
         assert.equal(contextData.usedMemPct, this.entityData.usedMemPct);

--- a/ngsi_adapter/src/test/unit/test_check_mem.sh.js
+++ b/ngsi_adapter/src/test/unit/test_check_mem.sh.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Telefónica I+D
+ * Copyright 2013-2015 Telefónica I+D
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -32,9 +32,9 @@ var util = require('util'),
 
 
 /* jshint laxbreak: true */
-suite('check_mem.sh', function() {
+suite('check_mem.sh', function () {
 
-    suiteSetup(function() {
+    suiteSetup(function () {
         this.timestampName = require('../../lib/parsers/common/base').parser.timestampAttrName;
         this.factory = require('../../lib/parsers/common/factory');
 
@@ -48,50 +48,56 @@ suite('check_mem.sh', function() {
         this.probeData = {
             usedMemPct: this.entityData.usedMemPct
         };
+
         this.probeBody = {
             data: 'Memory: OK Total: 1877 MB - Used: 369 MB - ' + this.probeData.usedMemPct + '% used',
             perf: 'TOTAL=1969020928;;;; USED=386584576;;;; CACHE=999440384;;;; BUFFER=201584640;;;;'
         };
     });
 
-    suiteTeardown(function() {
+    suiteTeardown(function () {
     });
 
-    setup(function() {
+    setup(function () {
         this.request = {
-            url: this.baseurl + '?id=' + this.entityId + '&type=' + this.entityType,
-            timestamp: Date.now()
+            url: this.baseurl + '?id=' + this.entityId + '&type=' + this.entityType
         };
-        this.entityData[this.timestampName] = this.request.timestamp;
+        this.reqdomain = {
+            timestamp: Date.now(),
+            entityId: this.entityId,
+            entityType: this.entityType
+        };
+        this.entityData[this.timestampName] = this.reqdomain.timestamp;
     });
 
-    teardown(function() {
+    teardown(function () {
         delete this.request;
+        delete this.reqdomain;
         delete this.entityData[this.timestampName];
     });
 
-    test('get_update_request_fails_with_invalid_check_mem.sh_content', function() {
-        this.request.body = 'XXX INVALID XXX';
+    test('get_update_request_fails_with_invalid_check_mem.sh_content', function () {
+        this.reqdomain.body = 'XXX INVALID XXX';
         var self = this;
         var parser = this.factory.getParser(self.request);
         assert.throws(
-            function() {
-                return parser.updateContextRequest(self.request);
+            function () {
+                return parser.updateContextRequest(self.reqdomain);
             }
         );
     });
 
-    test('get_update_request_ok_with_valid_check_mem.sh_content', function() {
-        this.request.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
+    test('get_update_request_ok_with_valid_check_mem.sh_content', function () {
+        this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
-        var update = parser.updateContextRequest(this.request);
+        var update = parser.updateContextRequest(this.reqdomain);
         common.assertValidUpdateXML(update, this);
     });
 
-    test('parse_ok_used_mem_percentage', function() {
-        this.request.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
+    test('parse_ok_used_mem_percentage', function () {
+        this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
-        var requestData = parser.parseRequest(this.request);
+        var requestData = parser.parseRequest(this.reqdomain.body);
         var contextData = parser.getContextAttrs(requestData);
         assert(contextData.usedMemPct);
         assert.equal(contextData.usedMemPct, this.entityData.usedMemPct);

--- a/ngsi_adapter/src/test/unit/test_check_procs.js
+++ b/ngsi_adapter/src/test/unit/test_check_procs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Telefónica I+D
+ * Copyright 2013-2015 Telefónica I+D
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -32,9 +32,9 @@ var util = require('util'),
 
 
 /* jshint laxbreak: true */
-suite('check_procs', function() {
+suite('check_procs', function () {
 
-    suiteSetup(function() {
+    suiteSetup(function () {
         this.timestampName = require('../../lib/parsers/common/base').parser.timestampAttrName;
         this.factory = require('../../lib/parsers/common/factory');
 
@@ -48,56 +48,62 @@ suite('check_procs', function() {
         this.probeData = {
             procs: this.entityData.procs
         };
+
         this.probeBody = {
             data: util.format('PROCS OK: %d processes', this.probeData.procs)
         };
     });
 
-    suiteTeardown(function() {
+    suiteTeardown(function () {
     });
 
-    setup(function() {
+    setup(function () {
         this.request = {
-            url: this.baseurl + '?id=' + this.entityId + '&type=' + this.entityType,
-            timestamp: Date.now()
+            url: this.baseurl + '?id=' + this.entityId + '&type=' + this.entityType
         };
-        this.entityData[this.timestampName] = this.request.timestamp;
+        this.reqdomain = {
+            timestamp: Date.now(),
+            entityId: this.entityId,
+            entityType: this.entityType
+        };
+        this.entityData[this.timestampName] = this.reqdomain.timestamp;
     });
 
-    teardown(function() {
+    teardown(function () {
         delete this.request;
+        delete this.reqdomain;
         delete this.entityData[this.timestampName];
     });
 
-    test('get_update_request_fails_with_invalid_check_procs_content', function() {
-        this.request.body = 'XXX INVALID XXX';
+    test('get_update_request_fails_with_invalid_check_procs_content', function () {
+        this.reqdomain.body = 'XXX INVALID XXX';
         var self = this;
         var parser = this.factory.getParser(self.request);
         assert.throws(
-            function() {
-                return parser.updateContextRequest(self.request);
+            function () {
+                return parser.updateContextRequest(self.reqdomain);
             }
         );
     });
 
-    test('get_update_request_ok_with_valid_check_procs_content', function() {
-        this.request.body = util.format('%s', this.probeBody.data);
+    test('get_update_request_ok_with_valid_check_procs_content', function () {
+        this.reqdomain.body = util.format('%s', this.probeBody.data);
         var parser = this.factory.getParser(this.request);
-        var update = parser.updateContextRequest(this.request);
+        var update = parser.updateContextRequest(this.reqdomain);
         common.assertValidUpdateXML(update, this);
     });
 
-    test('get_update_request_ok_with_another_threshold_metric', function() {
-        this.request.body = util.format('%s', this.probeBody.data).replace(/^PROCS/, 'VSZ');
+    test('get_update_request_ok_with_another_threshold_metric', function () {
+        this.reqdomain.body = util.format('%s', this.probeBody.data).replace(/^PROCS/, 'VSZ');
         var parser = this.factory.getParser(this.request);
-        var update = parser.updateContextRequest(this.request);
+        var update = parser.updateContextRequest(this.reqdomain);
         common.assertValidUpdateXML(update, this);
     });
 
-    test('parse_ok_number_of_procs', function() {
-        this.request.body = util.format('%s', this.probeBody.data);
+    test('parse_ok_number_of_procs', function () {
+        this.reqdomain.body = util.format('%s', this.probeBody.data);
         var parser = this.factory.getParser(this.request);
-        var requestData = parser.parseRequest(this.request);
+        var requestData = parser.parseRequest(this.reqdomain.body);
         var contextData = parser.getContextAttrs(requestData);
         assert(contextData.procs);
         assert.equal(contextData.procs, this.entityData.procs);

--- a/ngsi_adapter/src/test/unit/test_check_procs.js
+++ b/ngsi_adapter/src/test/unit/test_check_procs.js
@@ -103,7 +103,7 @@ suite('check_procs', function () {
     test('parse_ok_number_of_procs', function () {
         this.reqdomain.body = util.format('%s', this.probeBody.data);
         var parser = this.factory.getParser(this.request);
-        var requestData = parser.parseRequest(this.reqdomain.body);
+        var requestData = parser.parseRequest(this.reqdomain);
         var contextData = parser.getContextAttrs(requestData);
         assert(contextData.procs);
         assert.equal(contextData.procs, this.entityData.procs);

--- a/ngsi_adapter/src/test/unit/test_check_users.js
+++ b/ngsi_adapter/src/test/unit/test_check_users.js
@@ -97,7 +97,7 @@ suite('check_users', function () {
     test('parse_ok_number_of_users_logged_in', function () {
         this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
-        var requestData = parser.parseRequest(this.reqdomain.body);
+        var requestData = parser.parseRequest(this.reqdomain);
         var contextData = parser.getContextAttrs(requestData);
         assert(contextData.users);
         assert.equal(contextData.users, this.entityData.users);

--- a/ngsi_adapter/src/test/unit/test_check_users.js
+++ b/ngsi_adapter/src/test/unit/test_check_users.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Telefónica I+D
+ * Copyright 2013-2015 Telefónica I+D
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -32,9 +32,9 @@ var util = require('util'),
 
 
 /* jshint laxbreak: true */
-suite('check_users', function() {
+suite('check_users', function () {
 
-    suiteSetup(function() {
+    suiteSetup(function () {
         this.timestampName = require('../../lib/parsers/common/base').parser.timestampAttrName;
         this.factory = require('../../lib/parsers/common/factory');
 
@@ -48,50 +48,56 @@ suite('check_users', function() {
         this.probeData = {
             users: this.entityData.users
         };
+
         this.probeBody = {
             data: util.format('USERS OK - %d users currently logged in ', this.probeData.users),
             perf: util.format('users=%d;10;15;0', this.probeData.users)
         };
     });
 
-    suiteTeardown(function() {
+    suiteTeardown(function () {
     });
 
-    setup(function() {
+    setup(function () {
         this.request = {
-            url: this.baseurl + '?id=' + this.entityId + '&type=' + this.entityType,
-            timestamp: Date.now()
+            url: this.baseurl + '?id=' + this.entityId + '&type=' + this.entityType
         };
-        this.entityData[this.timestampName] = this.request.timestamp;
+        this.reqdomain = {
+            timestamp: Date.now(),
+            entityId: this.entityId,
+            entityType: this.entityType
+        };
+        this.entityData[this.timestampName] = this.reqdomain.timestamp;
     });
 
-    teardown(function() {
+    teardown(function () {
         delete this.request;
+        delete this.reqdomain;
         delete this.entityData[this.timestampName];
     });
 
-    test('get_update_request_fails_with_invalid_check_users_content', function() {
-        this.request.body = 'XXX INVALID XXX';
+    test('get_update_request_fails_with_invalid_check_users_content', function () {
+        this.reqdomain.body = 'XXX INVALID XXX';
         var self = this;
         var parser = this.factory.getParser(self.request);
         assert.throws(
-            function() {
-                return parser.updateContextRequest(self.request);
+            function () {
+                return parser.updateContextRequest(self.reqdomain);
             }
         );
     });
 
-    test('get_update_request_ok_with_valid_check_users_content', function() {
-        this.request.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
+    test('get_update_request_ok_with_valid_check_users_content', function () {
+        this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
-        var update = parser.updateContextRequest(this.request);
+        var update = parser.updateContextRequest(this.reqdomain);
         common.assertValidUpdateXML(update, this);
     });
 
-    test('parse_ok_number_of_users_logged_in', function() {
-        this.request.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
+    test('parse_ok_number_of_users_logged_in', function () {
+        this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
-        var requestData = parser.parseRequest(this.request);
+        var requestData = parser.parseRequest(this.reqdomain.body);
         var contextData = parser.getContextAttrs(requestData);
         assert(contextData.users);
         assert.equal(contextData.users, this.entityData.users);

--- a/ngsi_adapter/src/test/unit/test_nagios_parser.js
+++ b/ngsi_adapter/src/test/unit/test_nagios_parser.js
@@ -47,101 +47,119 @@ suite('nagios_parser', function () {
     });
 
     test('parse_fails_extra_perf_data_first_line', function () {
-        var requestMsg = 'TEXT DATA OUTPUT | OPTIONAL PERFDATA | ANOTHER PERFDATA';
+        var reqdomain = {
+            body: 'TEXT DATA OUTPUT | OPTIONAL PERFDATA | ANOTHER PERFDATA'
+        };
         assert.throws(
             function () {
-                parser.parseRequest(requestMsg);
+                parser.parseRequest(reqdomain);
             },
             /Invalid/
         );
     });
 
     test('parse_fails_extra_perf_data_another_line', function () {
-        var requestMsg = 'TEXT DATA OUTPUT | OPTIONAL PERFDATA                    \n' +
-                         'LONG TEXT LINE 1                                        \n' +
-                         'LONG TEXT LINE 2                                        \n' +
-                         'LONG TEXT LINE 3 | PERFDATA LINE 2 | ANOTHER PERFDATA   \n' +
-                         'LONG TEXT LINE 4                                        \n' +
-                         'LONG TEXT LINE 5 | PERFDATA LINE 3                      \n' +
-                         'LONG TEXT LINE 6                                        ';
+        var reqdomain = {
+            body: 'TEXT DATA OUTPUT | OPTIONAL PERFDATA                    \n' +
+                  'LONG TEXT LINE 1                                        \n' +
+                  'LONG TEXT LINE 2                                        \n' +
+                  'LONG TEXT LINE 3 | PERFDATA LINE 2 | ANOTHER PERFDATA   \n' +
+                  'LONG TEXT LINE 4                                        \n' +
+                  'LONG TEXT LINE 5 | PERFDATA LINE 3                      \n' +
+                  'LONG TEXT LINE 6'
+        };
         assert.throws(
             function () {
-                parser.parseRequest(requestMsg);
+                parser.parseRequest(reqdomain);
             },
             /Invalid/
         );
     });
 
     test('parse_fails_third_perf_data_compound_line', function () {
-        var requestMsg = 'TEXT OUTPUT | OPTIONAL PERFDATA                         \n' +
-                         'LONG TEXT LINE 1                                        \n' +
-                         'LONG TEXT LINE 2                                        \n' +
-                         'LONG TEXT LINE 3 | PERFDATA LINE 2                      \n' +
-                         'LONG TEXT LINE 4                                        \n' +
-                         'LONG TEXT LINE 5 | PERFDATA LINE 3                      \n' +
-                         'LONG TEXT LINE 6                                        ';
+        var reqdomain = {
+            body: 'TEXT OUTPUT | OPTIONAL PERFDATA                         \n' +
+                  'LONG TEXT LINE 1                                        \n' +
+                  'LONG TEXT LINE 2                                        \n' +
+                  'LONG TEXT LINE 3 | PERFDATA LINE 2                      \n' +
+                  'LONG TEXT LINE 4                                        \n' +
+                  'LONG TEXT LINE 5 | PERFDATA LINE 3                      \n' +
+                  'LONG TEXT LINE 6'
+        };
         assert.throws(
             function () {
-                parser.parseRequest(requestMsg);
+                parser.parseRequest(reqdomain);
             },
             /Invalid/
         );
     });
 
     test('parse_ok_singleline_text_output_only', function () {
-        var data = 'TEXT OUTPUT';
-        var requestMsg = data;
-        var entityData = parser.parseRequest(requestMsg);
+        var data = 'TEXT OUTPUT',
+            reqdomain = {
+                body: data
+            },
+            entityData = parser.parseRequest(reqdomain);
         assert(!entityData.perfData);
         assert.equal(entityData.data, data);
     });
 
     test('parse_ok_multiline_text_output_only', function () {
-        var data = 'TEXT OUTPUT         \n' +
-                   'LONG TEXT LINE 1    \n' +
-                   'LONG TEXT LINE 2    ';
-        var requestMsg = data;
-        var entityData = parser.parseRequest(requestMsg);
+        var data = 'TEXT OUTPUT      \n' +
+                   'LONG TEXT LINE 1 \n' +
+                   'LONG TEXT LINE 2',
+            reqdomain = {
+                body: data
+            },
+            entityData = parser.parseRequest(reqdomain);
         assert(!entityData.perfData);
         assert(entityData.data.split('\n').length > 1);
         assert.equal(entityData.data, data);
     });
 
     test('parse_ok_singleline_text_output_singleline_perf_data', function () {
-        var data = 'TEXT OUTPUT';
-        var perf = 'OPTIONAL PERFDATA';
-        var requestMsg = util.format('%s|%s', data, perf);
-        var entityData = parser.parseRequest(requestMsg);
+        var data = 'TEXT OUTPUT',
+            perf = 'OPTIONAL PERFDATA',
+            reqdomain = {
+                body: util.format('%s|%s', data, perf)
+            },
+            entityData = parser.parseRequest(reqdomain);
         assert.equal(entityData.perfData, perf);
         assert.equal(entityData.data, data);
     });
 
     test('parse_fails_singleline_text_output_multiline_perf_data', function () {
-        var data = 'TEXT OUTPUT';
-        var perf = 'OPTIONAL PERFDATA\n| PERFDATA LINE 2';
-        var requestMsg = util.format('%s|%s', data, perf);
+        var data = 'TEXT OUTPUT',
+            perf = 'OPTIONAL PERFDATA\n| PERFDATA LINE 2',
+            reqdomain = {
+                body: util.format('%s|%s', data, perf)
+            };
         assert.throws(
             function () {
-                parser.parseRequest(requestMsg);
+                parser.parseRequest(reqdomain);
             },
             /Invalid/
         );
     });
 
     test('parse_ok_multiline_text_output_singleline_perf_data', function () {
-        var data = ['TEXT OUTPUT', 'LONG TEXT LINE 1', 'LONG TEXT LINE 2'];
-        var perf = 'OPTIONAL PERFDATA';
-        var requestMsg = util.format('%s|%s\n%s\n%s', data[0], perf, data[1], data[2]);
-        var entityData = parser.parseRequest(requestMsg);
+        var data = ['TEXT OUTPUT', 'LONG TEXT LINE 1', 'LONG TEXT LINE 2'],
+            perf = 'OPTIONAL PERFDATA',
+            reqdomain = {
+                body: util.format('%s|%s\n%s\n%s', data[0], perf, data[1], data[2])
+            },
+            entityData = parser.parseRequest(reqdomain);
         assert.equal(entityData.perfData, perf);
         assert.deepEqual(entityData.data.split('\n'), data);
     });
 
     test('parse_ok_multiline_text_output_multiline_perf_data', function () {
-        var data = ['TEXT OUTPUT', 'LONG TEXT LINE 1', 'LONG TEXT LINE 2'];
-        var perf = ['OPTIONAL PERFDATA', 'PERFDATA LINE 2', 'PERFDATA LINE 3'];
-        var requestMsg = util.format('%s|%s\n%s\n%s|%s\n%s', data[0], perf[0], data[1], data[2], perf[1], perf[2]);
-        var entityData = parser.parseRequest(requestMsg);
+        var data = ['TEXT OUTPUT', 'LONG TEXT LINE 1', 'LONG TEXT LINE 2'],
+            perf = ['OPTIONAL PERFDATA', 'PERFDATA LINE 2', 'PERFDATA LINE 3'],
+            reqdomain = {
+                body: util.format('%s|%s\n%s\n%s|%s\n%s', data[0], perf[0], data[1], data[2], perf[1], perf[2])
+            };
+        var entityData = parser.parseRequest(reqdomain);
         assert.deepEqual(entityData.perfData.split('\n'), perf);
         assert.deepEqual(entityData.data.split('\n'), data);
     });

--- a/ngsi_adapter/src/test/unit/test_nagios_parser.js
+++ b/ngsi_adapter/src/test/unit/test_nagios_parser.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Telefónica I+D
+ * Copyright 2013-2015 Telefónica I+D
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -32,130 +32,116 @@ var util = require('util'),
 
 
 /* jshint multistr: true */
-suite('nagios_parser', function() {
+suite('nagios_parser', function () {
 
-    suiteSetup(function() {
-        this.request = { url: 'http://hostname:1234/path?query' };
+    suiteSetup(function () {
     });
 
-    suiteTeardown(function() {
+    suiteTeardown(function () {
     });
 
-    setup(function() {
+    setup(function () {
     });
 
-    teardown(function() {
-        delete this.request.body;
+    teardown(function () {
     });
 
-    test('parse_fails_extra_perf_data_first_line', function() {
-        var self = this;
-        var data = 'TEXT OUTPUT | OPTIONAL PERFDATA | ANOTHER PERFDATA';
-        self.request.body = data;
+    test('parse_fails_extra_perf_data_first_line', function () {
+        var requestMsg = 'TEXT DATA OUTPUT | OPTIONAL PERFDATA | ANOTHER PERFDATA';
         assert.throws(
-            function() {
-                parser.parseRequest(self.request);
+            function () {
+                parser.parseRequest(requestMsg);
             },
             /Invalid/
         );
     });
 
-    test('parse_fails_extra_perf_data_another_line', function() {
-        var self = this;
-        var data = 'TEXT OUTPUT | OPTIONAL PERFDATA                         \n' +
-                   'LONG TEXT LINE 1                                        \n' +
-                   'LONG TEXT LINE 2                                        \n' +
-                   'LONG TEXT LINE 3 | PERFDATA LINE 2 | ANOTHER PERFDATA   \n' +
-                   'LONG TEXT LINE 4                                        \n' +
-                   'LONG TEXT LINE 5 | PERFDATA LINE 3                      \n' +
-                   'LONG TEXT LINE 6                                        ';
-        self.request.body = data;
+    test('parse_fails_extra_perf_data_another_line', function () {
+        var requestMsg = 'TEXT DATA OUTPUT | OPTIONAL PERFDATA                    \n' +
+                         'LONG TEXT LINE 1                                        \n' +
+                         'LONG TEXT LINE 2                                        \n' +
+                         'LONG TEXT LINE 3 | PERFDATA LINE 2 | ANOTHER PERFDATA   \n' +
+                         'LONG TEXT LINE 4                                        \n' +
+                         'LONG TEXT LINE 5 | PERFDATA LINE 3                      \n' +
+                         'LONG TEXT LINE 6                                        ';
         assert.throws(
-            function() {
-                parser.parseRequest(self.request);
+            function () {
+                parser.parseRequest(requestMsg);
             },
             /Invalid/
         );
     });
 
-    test('parse_fails_third_perf_data_compound_line', function() {
-        var self = this;
-        var data = 'TEXT OUTPUT | OPTIONAL PERFDATA                         \n' +
-                   'LONG TEXT LINE 1                                        \n' +
-                   'LONG TEXT LINE 2                                        \n' +
-                   'LONG TEXT LINE 3 | PERFDATA LINE 2                      \n' +
-                   'LONG TEXT LINE 4                                        \n' +
-                   'LONG TEXT LINE 5 | PERFDATA LINE 3                      \n' +
-                   'LONG TEXT LINE 6                                        ';
-        self.request.body = data;
+    test('parse_fails_third_perf_data_compound_line', function () {
+        var requestMsg = 'TEXT OUTPUT | OPTIONAL PERFDATA                         \n' +
+                         'LONG TEXT LINE 1                                        \n' +
+                         'LONG TEXT LINE 2                                        \n' +
+                         'LONG TEXT LINE 3 | PERFDATA LINE 2                      \n' +
+                         'LONG TEXT LINE 4                                        \n' +
+                         'LONG TEXT LINE 5 | PERFDATA LINE 3                      \n' +
+                         'LONG TEXT LINE 6                                        ';
         assert.throws(
-            function() {
-                parser.parseRequest(self.request);
+            function () {
+                parser.parseRequest(requestMsg);
             },
             /Invalid/
         );
     });
 
-    test('parse_ok_singleline_text_output_only', function() {
-        var self = this;
+    test('parse_ok_singleline_text_output_only', function () {
         var data = 'TEXT OUTPUT';
-        self.request.body = data;
-        var entityData = parser.parseRequest(self.request);
+        var requestMsg = data;
+        var entityData = parser.parseRequest(requestMsg);
         assert(!entityData.perfData);
         assert.equal(entityData.data, data);
     });
 
-    test('parse_ok_multiline_text_output_only', function() {
-        var self = this;
+    test('parse_ok_multiline_text_output_only', function () {
         var data = 'TEXT OUTPUT         \n' +
                    'LONG TEXT LINE 1    \n' +
                    'LONG TEXT LINE 2    ';
-        self.request.body = data;
-        var entityData = parser.parseRequest(self.request);
+        var requestMsg = data;
+        var entityData = parser.parseRequest(requestMsg);
         assert(!entityData.perfData);
         assert(entityData.data.split('\n').length > 1);
         assert.equal(entityData.data, data);
     });
 
-    test('parse_ok_singleline_text_output_singleline_perf_data', function() {
-        var self = this;
+    test('parse_ok_singleline_text_output_singleline_perf_data', function () {
         var data = 'TEXT OUTPUT';
         var perf = 'OPTIONAL PERFDATA';
-        self.request.body = util.format('%s|%s', data, perf);
-        var entityData = parser.parseRequest(self.request);
+        var requestMsg = util.format('%s|%s', data, perf);
+        var entityData = parser.parseRequest(requestMsg);
         assert.equal(entityData.perfData, perf);
         assert.equal(entityData.data, data);
     });
 
-    test('parse_fails_singleline_text_output_multiline_perf_data', function() {
-        var self = this;
+    test('parse_fails_singleline_text_output_multiline_perf_data', function () {
         var data = 'TEXT OUTPUT';
         var perf = 'OPTIONAL PERFDATA\n| PERFDATA LINE 2';
-        self.request.body = util.format('%s|%s', data, perf);
+        var requestMsg = util.format('%s|%s', data, perf);
         assert.throws(
-            function() {
-                parser.parseRequest(self.request);
+            function () {
+                parser.parseRequest(requestMsg);
             },
             /Invalid/
         );
     });
 
-    test('parse_ok_multiline_text_output_singleline_perf_data', function() {
-        var self = this;
+    test('parse_ok_multiline_text_output_singleline_perf_data', function () {
         var data = ['TEXT OUTPUT', 'LONG TEXT LINE 1', 'LONG TEXT LINE 2'];
         var perf = 'OPTIONAL PERFDATA';
-        self.request.body = util.format('%s|%s\n%s\n%s', data[0], perf, data[1], data[2]);
-        var entityData = parser.parseRequest(self.request);
+        var requestMsg = util.format('%s|%s\n%s\n%s', data[0], perf, data[1], data[2]);
+        var entityData = parser.parseRequest(requestMsg);
         assert.equal(entityData.perfData, perf);
         assert.deepEqual(entityData.data.split('\n'), data);
     });
 
-    test('parse_ok_multiline_text_output_multiline_perf_data', function() {
-        var self = this;
+    test('parse_ok_multiline_text_output_multiline_perf_data', function () {
         var data = ['TEXT OUTPUT', 'LONG TEXT LINE 1', 'LONG TEXT LINE 2'];
         var perf = ['OPTIONAL PERFDATA', 'PERFDATA LINE 2', 'PERFDATA LINE 3'];
-        self.request.body = util.format('%s|%s\n%s\n%s|%s\n%s', data[0], perf[0], data[1], data[2], perf[1], perf[2]);
-        var entityData = parser.parseRequest(self.request);
+        var requestMsg = util.format('%s|%s\n%s\n%s|%s\n%s', data[0], perf[0], data[1], data[2], perf[1], perf[2]);
+        var entityData = parser.parseRequest(requestMsg);
         assert.deepEqual(entityData.perfData.split('\n'), perf);
         assert.deepEqual(entityData.data.split('\n'), data);
     });

--- a/ngsi_adapter/src/test/unit/test_options.js
+++ b/ngsi_adapter/src/test/unit/test_options.js
@@ -24,7 +24,6 @@
 
 
 'use strict';
-/* jshint -W069 */
 
 
 /** Fake command line arguments (required to load `adapter` without complaining) */
@@ -91,7 +90,6 @@ suite('options', function () {
 
     teardown(function () {
         delete this.udpServer;
-        process.removeAllListeners();
     });
 
     test('adapter_starts_listening_to_http_requests_at_default_port', function () {

--- a/ngsi_adapter/src/test/unit/test_options.js
+++ b/ngsi_adapter/src/test/unit/test_options.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2015 Telefónica I+D
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * Module that defines unit tests for the configuration options of the adapter.
+ *
+ * @module test_options
+ */
+
+
+'use strict';
+/* jshint -W069 */
+
+
+/** Fake command line arguments (required to load `adapter` without complaining) */
+process.argv = [];
+
+
+var util = require('util'),
+    http = require('http'),
+    dgram = require('dgram'),
+    sinon = require('sinon'),
+    assert = require('assert'),
+    Emitter = require('events').EventEmitter,
+    defaults = require('../../lib/common').defaults,
+    logger = require('../../lib/logger'),
+    adapter = require('../../lib/adapter'),
+    opts = require('../../config/options');
+
+
+/* jshint multistr: true */
+suite('options', function () {
+
+    suiteSetup(function () {
+        var self = this;
+        self.baseurl = 'http://hostname:1234';
+        self.resource = 'check_load';
+        self.body = 'invalid load data';
+        self.headers = {};
+        sinon.stub(http, 'createServer', function () {
+            self.httpListener = arguments[0];
+            self.serverListen = sinon.spy(function (port, host, callback) {
+                this.address = sinon.stub().returns({address: host, port: port});
+                callback.call(this);
+            });
+            return {
+                listen: self.serverListen
+            };
+        });
+        sinon.stub(dgram, 'createSocket', function () {
+            var udpSocket = new Emitter();
+            udpSocket.bind = sinon.spy(function (port, host, callback) {
+                self.udpServer = this;
+                this.address = sinon.stub().returns({ address: host, port: port });
+                callback.call(this);
+            });
+            /* jshint -W072 */
+            udpSocket.send = function (buf, offset, length, port, address, callback) {
+                self.udpServer.emit('message', buf.toString('utf8', offset, length - offset));
+                callback.call(this, null, length - offset);
+            };
+            udpSocket.close = sinon.stub();
+            return udpSocket;
+        });
+        logger.stream = require('dev-null')();
+        logger.setLevel('DEBUG');
+    });
+
+    suiteTeardown(function () {
+        http.createServer.restore();
+        dgram.createSocket.restore();
+    });
+
+    setup(function () {
+    });
+
+    teardown(function () {
+        delete this.udpServer;
+        process.removeAllListeners();
+    });
+
+    test('adapter_starts_listening_to_http_requests_at_default_port', function () {
+        adapter.main();
+        assert(this.serverListen.calledOnce);
+        assert(this.serverListen.args[0][0], defaults.listenPort);
+    });
+
+    test('adapter_starts_but_logs_warning_message_when_invalid_udp_endpoints', function () {
+        var self = this,
+            udpEndpointNoParser = 'host:port:',
+            optsUdpEndpointsSave = opts.udpEndpoints,
+            logWarn = sinon.stub(logger, 'warn', function () {
+                self.logWarnErrMsg = util.format.apply(null, arguments);
+                logWarn.restore();
+            });
+        opts.udpEndpoints = udpEndpointNoParser;
+        adapter.main();
+        opts.udpEndpoints = optsUdpEndpointsSave;
+        assert(this.serverListen.calledOnce);
+        assert(!this.udpServer);
+        assert.notEqual(this.logWarnErrMsg.indexOf('Ignoring UDP endpoint'), -1);
+        assert.notEqual(this.logWarnErrMsg.indexOf('missing parser name'), -1);
+    });
+
+    test('adapter_starts_listening_to_both_http_and_udp_requests', function () {
+        var udpParser = 'parser',
+            udpHost = 'localhost',
+            udpPort = 1234,
+            optsUdpEndpointsSave = opts.udpEndpoints;
+        opts.udpEndpoints = util.format('%s:%d:%s', udpHost, udpPort, udpParser);
+        adapter.main();
+        opts.udpEndpoints = optsUdpEndpointsSave;
+        assert(this.serverListen.calledOnce);
+        assert(this.serverListen.args[0][0], defaults.listenPort);
+        assert(this.udpServer.bind.calledOnce);
+        assert(this.udpServer.bind.args[0][0], udpPort);
+        assert(this.udpServer.bind.args[0][1], udpHost);
+        this.udpServer.removeAllListeners();
+    });
+
+});


### PR DESCRIPTION
#### Reviewers
@flopezag @jesuspg 

#### Description
Add a new option to enable UDP listen points linked to a particular data parser. This way, external components like Ceilometer or Monasca could send its raw data for NGSI Adapter to transform into NGSI entity attributes and invoke Context Broker.

#### Testing
Verified.