### PR TITLE
Add directory search for additional parsers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,9 @@ The configuration used by the adapter service is optionally read from the file
 
     # ADAPTER_UDP_ENDPOINTS - UDP listen endpoints (host:port:parser,...)
 
+    # ADAPTER_PARSERS_PATH - Path with directories to look for parsers
+    ADAPTER_PARSERS_PATH=lib/parsers/nagios
+
     # ADAPTER_BROKER_URL - The endpoint where Context Broker is listening
     ADAPTER_BROKER_URL=http://127.0.0.1:1026/
 
@@ -229,6 +232,7 @@ Most of these attributes map to options of the `command line interface
 - ``ADAPTER_LISTEN_HOST`` maps to ``-H`` or ``--listenHost`` option
 - ``ADAPTER_LISTEN_PORT`` maps to ``-p`` or ``--listenPort`` option
 - ``ADAPTER_UDP_ENDPOINTS`` maps to ``-u`` or ``--udpEndpoints`` option
+- ``ADAPTER_PARSERS_PATH`` maps to ``-P`` or ``--parsersPath`` option
 - ``ADAPTER_BROKER_URL`` maps to ``-b`` or ``--brokerUrl`` option
 - ``ADAPTER_RETRIES`` maps to ``-r`` or ``--retries`` option
 

--- a/doc/manuals/admin/README.rst
+++ b/doc/manuals/admin/README.rst
@@ -97,7 +97,7 @@ Additional parsers
 NGSI Adapter currently includes a predefined set of parsers for Nagios probes
 at ``lib/parsers/nagios`` directory, each named after its corresponding probe.
 
-This can be extended with additional parsers found at from other directories.
+This can be extended with additional parsers found at additional directories.
 To do so, please configure ``--parsersPath`` command line option (or set the
 variable ``ADAPTER_PARSERS_PATH``) with a colon-separated list of absolute (or
 relative to Adapter root) directories where parsers are located.

--- a/doc/manuals/admin/README.rst
+++ b/doc/manuals/admin/README.rst
@@ -95,11 +95,12 @@ Additional parsers
 ~~~~~~~~~~~~~~~~~~
 
 NGSI Adapter currently includes a predefined set of parsers for Nagios probes
-at ``lib/parsers/`` directory, each parser named after its corresponding probe.
+at ``lib/parsers/nagios`` directory, each named after its corresponding probe.
 
-Whenever new Nagios probes are used, or even if we decide to use a different
-monitoring framework with its own set of probes, the corresponding parsers
-should be dropped in such directory.
+This can be extended with additional parsers found at from other directories.
+To do so, please configure ``--parsersPath`` command line option (or set the
+variable ``ADAPTER_PARSERS_PATH``) with a colon-separated list of absolute (or
+relative to Adapter root) directories where parsers are located.
 
 
 Installation of Context Broker
@@ -167,6 +168,8 @@ You can use these command line options (available typing ``adapter --help``):
    The port number at which NGSI Adapter listens
 -u, --udpEndpoints
    Optional list of UDP endpoints (host:port:parser)
+-P, --parsersPath
+   Colon-separated path with directories to look for parsers
 -b, --brokerUrl
    The URL of the Context Broker instance to publish data to
 -r, --retries

--- a/doc/manuals/user/README.rst
+++ b/doc/manuals/user/README.rst
@@ -92,12 +92,13 @@ about to be parsed.
 NGSI Adapter parsers
 --------------------
 
-NGSI Adapter processes requests asynchronously, trying to locate a valid parser
-named after the originating probe, located at ``lib/parsers/``. If probe is
-unknown, HTTP response status will be ``404``; otherwise, response status will
-be ``200``, parser will be dynamically loaded, and then its ``parseRequest()``
-and ``getContextAttrs()`` methods will be invoked. With the attribute list
-returned by the latter, Context Broker will be invoked.
+NGSI Adapter processes requests asynchronously, trying to load a valid parser
+named after the originating probe, located at any of the directories specified
+(see `Installation and Administration Guide <../admin/README.rst>`_). If probe
+is unknown (parser not found), HTTP response status will be ``404``; otherwise,
+response status will be ``200``, parser will be dynamically loaded, and then
+its ``parseRequest()`` and ``getContextAttrs()`` methods will be called. The
+attribute list returned by the latter will be used to invoke Context Broker.
 
 Custom parsers for new probes may be easily added to NGSI Adapter, just
 extending a base abstract object and implementing the aforementioned methods.
@@ -113,12 +114,11 @@ comma-separated list of values of two attributes *myAttr0* and *myAttr1*:
 .. code:: javascript
 
    /**
-    * module "lib.parsers.myProbe"
+    * module "myProbe" at any directory included in ADAPTER_PARSERS_PATH
     */
 
-   var baseParser = require('./common/base').parser,
-       myParser   = Object.create(baseParser);
-
+   // @augments base parser (must redefine parseRequest and getContextAttrs)
+   var myParser = Object.create(null);
 
    // @param Domain object including context, timestamp, id, type & body
    myParser.parseRequest = function (reqDomain) {

--- a/ngsi_adapter/README.rst
+++ b/ngsi_adapter/README.rst
@@ -24,6 +24,7 @@ Changelog
 
 Version 1.3.0
 
+- Add an option to specify a list of directories to look for parsers
 - Add support to UDP requests
 
 Version 1.2.4

--- a/ngsi_adapter/script/build/files/debian/changelog
+++ b/ngsi_adapter/script/build/files/debian/changelog
@@ -1,8 +1,8 @@
 fiware-monitoring-ngsi-adapter (1.3.0) precise; urgency=low
-
+  * Add an option to specify a list of directories to look for parsers
   * Add support to UDP requests
 
- -- Telefónica I+D <opensource@tid.es>  Wed, 11 Nov 2015 18:00:00 +0200
+ -- Telefónica I+D <opensource@tid.es>  Fri, 20 Nov 2015 18:00:00 +0200
 
 fiware-monitoring-ngsi-adapter (1.2.4) precise; urgency=low
 

--- a/ngsi_adapter/script/build/files/debian/ngsi_adapter.default
+++ b/ngsi_adapter/script/build/files/debian/ngsi_adapter.default
@@ -12,6 +12,9 @@ ADAPTER_LISTEN_PORT=1337
 
 # ADAPTER_UDP_ENDPOINTS - UDP listen endpoints (host:port:parser,...)
 
+# ADAPTER_PARSERS_PATH - Path with directories to look for parsers
+ADAPTER_PARSERS_PATH=lib/parsers/nagios
+
 # ADAPTER_BROKER_URL - The endpoint where Context Broker is listening
 ADAPTER_BROKER_URL=http://127.0.0.1:1026/
 

--- a/ngsi_adapter/script/build/files/redhat/SOURCES/etc/sysconfig/ngsi_adapter
+++ b/ngsi_adapter/script/build/files/redhat/SOURCES/etc/sysconfig/ngsi_adapter
@@ -12,6 +12,9 @@ ADAPTER_LISTEN_PORT=1337
 
 # ADAPTER_UDP_ENDPOINTS - UDP listen endpoints (host:port:parser,...)
 
+# ADAPTER_PARSERS_PATH - Path with directories to look for parsers
+ADAPTER_PARSERS_PATH=lib/parsers/nagios
+
 # ADAPTER_BROKER_URL - The endpoint where Context Broker is listening
 ADAPTER_BROKER_URL=http://127.0.0.1:1026/
 

--- a/ngsi_adapter/script/build/files/redhat/SPECS/fiware-monitoring-ngsi-adapter.spec
+++ b/ngsi_adapter/script/build/files/redhat/SPECS/fiware-monitoring-ngsi-adapter.spec
@@ -187,7 +187,8 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Wed Nov 11 2015 Telefónica I+D <opensource@tid.es> 1.3.0-1
+* Fri Nov 20 2015 Telefónica I+D <opensource@tid.es> 1.3.0-1
+- Add an option to specify a list of directories to look for parsers
 - Add support to UDP requests
 
 * Fri Aug 14 2015 Telefónica I+D <opensource@tid.es> 1.2.4-1

--- a/ngsi_adapter/src/Gruntfile.js
+++ b/ngsi_adapter/src/Gruntfile.js
@@ -22,8 +22,7 @@ module.exports = function(grunt) {
             reportTest: ['report/test'],
             reportLint: ['report/lint'],
             reportCoverage: ['report/coverage'],
-            siteCoverage: ['site/coverage'],
-            siteReport: ['site/report'],
+            siteComplexity: ['site/complexity'],
             siteDoc: ['site/doc']
         },
 
@@ -31,8 +30,7 @@ module.exports = function(grunt) {
             reportTest: ['<%= dirs.reportTest[0] %>'],
             reportLint: ['<%= dirs.reportLint[0] %>'],
             reportCoverage: ['<%= dirs.reportCoverage[0] %>'],
-            siteCoverage: ['<%= dirs.siteCoverage[0] %>'],
-            siteReport: ['<%= dirs.siteReport[0] %>'],
+            siteComplexity: ['<%= dirs.siteComplexity[0] %>'],
             siteDoc: ['<%= dirs.siteDoc[0] %>']
         },
 
@@ -52,19 +50,14 @@ module.exports = function(grunt) {
                     create: ['<%= dirs.reportCoverage[0] %>']
                 }
             },
-            siteCoverage: {
-                options: {
-                    create: ['<%= dirs.siteCoverage[0] %>']
-                }
-            },
             siteDoc: {
                 options: {
                     create: ['<%= dirs.siteDoc[0] %>']
                 }
             },
-            siteReport: {
+            siteComplexity: {
                 options: {
-                    create: ['<%= dirs.siteReport[0] %>']
+                    create: ['<%= dirs.siteComplexity[0] %>']
                 }
             }
         },
@@ -160,22 +153,13 @@ module.exports = function(grunt) {
                     reportFormats: ['lcovonly']
                 }
             },
-            coverageHtml: {
-                src: '<%= dirs.test[0] %>',
-                options: {
-                    quiet: true,
-                    root: '<%= dirs.lib[0] %>',
-                    coverageFolder: '<%= dirs.siteCoverage[0] %>',
-                    reportFormats: ['lcov']
-                }
-            },
-            coberturaReport: {
+            coverageReport: {
                 src: '<%= dirs.test[0] %>',
                 options: {
                     quiet: true,
                     root: '<%= dirs.lib[0] %>',
                     coverageFolder: '<%= dirs.reportCoverage[0] %>',
-                    reportFormats: ['lcovonly', 'cobertura']
+                    reportFormats: ['lcov', 'cobertura']
                 }
             }
         },
@@ -196,7 +180,7 @@ module.exports = function(grunt) {
             },
             lib: {
                 files: {
-                    '<%= clean.siteReport[0] %>': '<%= jshint.lib.src %>'
+                    '<%= dirs.siteComplexity[0] %>': ['<%= jshint.lib.src %>', '<%= jshint.test.src %>']
                 }
             }
         },
@@ -224,7 +208,7 @@ module.exports = function(grunt) {
                 options: {
                     reporter: {
                         name: 'gjslint_xml',
-                        dest: '<%= clean.reportLint[0] %>/gjslint.xml'
+                        dest: '<%= dirs.reportLint[0] %>/gjslint.xml'
                     },
                     flags: [
                         '--flagfile .gjslintrc'
@@ -241,8 +225,7 @@ module.exports = function(grunt) {
         return ('--' + opt + ',' + this[opt]).replace(/--ignoreLeaks,false/, '--check-leaks');
     }, mochaTestOptions).join().split(',');
     grunt.config('mocha_istanbul.coverage.options.mochaOptions', mochaTestOptionsArray);
-    grunt.config('mocha_istanbul.coverageHtml.options.mochaOptions', mochaTestOptionsArray);
-    grunt.config('mocha_istanbul.coberturaReport.options.mochaOptions', mochaTestOptionsArray);
+    grunt.config('mocha_istanbul.coverageReport.options.mochaOptions', mochaTestOptionsArray);
 
     grunt.registerTask('test', 'Run tests',
         ['mochaTest:unit']);
@@ -253,17 +236,14 @@ module.exports = function(grunt) {
     grunt.registerTask('coverage', 'Print coverage summary',
         ['mocha_istanbul:coverage']);
 
-    grunt.registerTask('coverage-report', 'Generate Cobertura report',
-        ['mocha_istanbul:coberturaReport']);
-
-    grunt.registerTask('coverage-html', 'Generate HTML site with coverage',
-        ['mocha_istanbul:coverageHtml']);
+    grunt.registerTask('coverage-report', 'Generate coverage reports',
+        ['mocha_istanbul:coverageReport']);
 
     grunt.registerTask('complexity', 'Generate code complexity reports',
-        ['plato']);
+        ['mkdir:siteComplexity', 'plato']);
 
     grunt.registerTask('doc', 'Generate source code JSDoc',
-        ['dox']);
+        ['mkdir:siteDoc', 'dox']);
 
     grunt.registerTask('lint-jshint', 'Check source code style with JsHint',
         ['jshint:gruntfile', 'jshint:lib', 'jshint:test']);
@@ -279,7 +259,7 @@ module.exports = function(grunt) {
         'jshint:reportTest', 'gjslint:report']);
 
     grunt.registerTask('site',
-        ['doc', 'coverage-html', 'complexity']);
+        ['doc', 'complexity']);
 
     // Default task.
     grunt.registerTask('default',

--- a/ngsi_adapter/src/config/options.js
+++ b/ngsi_adapter/src/config/options.js
@@ -37,6 +37,7 @@ var defaults = require('../lib/common').defaults;
  * @property {String} opts.listenHost       Adapter listen HTTP host.
  * @property {Number} opts.listenPort       Adapter listen HTTP port.
  * @property {String} opts.udpEndpoints     Comma-separated list of UDP endpoints (host:port:parser).
+ * @property {String} opts.parsersPath      Colon-separated path with directories to look for parsers.
  * @property {Number} opts.retries          Maximum number of Context Broker invocation retries.
  */
 var opts = require('optimist')
@@ -56,6 +57,10 @@ var opts = require('optimist')
         alias: 'udpEndpoints',
         'default': process.env['ADAPTER_UDP_ENDPOINTS'] || defaults.udpEndpoints,
         describe: 'List of UDP endpoints (host:port:parser)'
+    }).options('P', {
+        alias: 'parsersPath',
+        'default': process.env['ADAPTER_PARSERS_PATH'] || defaults.parsersPath,
+        describe: 'Path to look for parsers'
     }).options('b', {
         alias: 'brokerUrl',
         'default': process.env['ADAPTER_BROKER_URL'] || defaults.brokerUrl,

--- a/ngsi_adapter/src/lib/adapter.js
+++ b/ngsi_adapter/src/lib/adapter.js
@@ -244,7 +244,7 @@ function main() {
     (opts.udpEndpoints || '').split(',').map(function (item) {
         var itemElements = item.split(':'),
             udpListenHost = itemElements[0] || opts.listenHost,
-            udpListenPort = itemElements[1] || opts.listenPort,
+            udpListenPort = parseInt(itemElements[1] || opts.listenPort, 10),
             udpParserName = itemElements[2];
 
         if (udpParserName) {

--- a/ngsi_adapter/src/lib/adapter.js
+++ b/ngsi_adapter/src/lib/adapter.js
@@ -26,6 +26,7 @@
 
 
 'use strict';
+/* jshint -W030 */
 
 
 var http = require('http'),
@@ -241,7 +242,7 @@ function main() {
     });
 
     /* Optionally bind this Adapter to a list of UDP endpoints, forwarding requests to the corresponding parser */
-    (opts.udpEndpoints || '').split(',').map(function (item) {
+    opts.udpEndpoints && opts.udpEndpoints.split(',').map(function (item) {
         var itemElements = item.split(':'),
             udpListenHost = itemElements[0] || opts.listenHost,
             udpListenPort = parseInt(itemElements[1] || opts.listenPort, 10),

--- a/ngsi_adapter/src/lib/common.js
+++ b/ngsi_adapter/src/lib/common.js
@@ -42,6 +42,7 @@ exports.txIdHttpHeader = 'txId';
  * @property {String} defaults.listenHost   Default adapter HTTP listen host.
  * @property {Number} defaults.listenPort   Default adapter HTTP listen port.
  * @property {String} defaults.udpEndpoints Default list of UDP endpoints (host:port:parser).
+ * @property {String} defaults.parsersPath  Default path with directories to look for parsers.
  * @property {Number} defaults.retries      Default maximum number of Context Broker invocation retries.
  */
 exports.defaults = {
@@ -50,5 +51,6 @@ exports.defaults = {
     listenHost: '0.0.0.0',
     listenPort: 1337,
     udpEndpoints: null,
+    parsersPath: 'lib/parsers:lib/parsers/nagios',
     retries: 2
 };

--- a/ngsi_adapter/src/lib/parsers/common/factory.js
+++ b/ngsi_adapter/src/lib/parsers/common/factory.js
@@ -24,27 +24,52 @@
 
 
 'use strict';
+/* jshint -W030 */
 
 
 var url = require('url'),
     util = require('util'),
-    path = require('path');
+    path = require('path'),
+    opts = require('../../../config/options'),
+    defaults = require('../../common').defaults,
+    baseParser = require('./base').parser,
+    parsersPath = opts.parsersPath + ':' + defaults.parsersPath,
+    absoluteBaseDir = path.normalize(__dirname + path.sep + '..' + path.sep + '..' + path.sep + '..');
 
 
 /**
- * Parser factory: returns a dynamically loaded parser object at `lib/parsers/{name}`.
+ * Cache of parsers already loaded.
+ */
+var parsersCache = {};
+
+
+/**
+ * Parser factory: returns a parser object from a dynamically loaded parser prototype from a module `name` located at
+ * any of the directories specified in `parsersPath` option, either absolute directories or relative to Adapter's root.
  *
  * @param {String} name  The name of the parser.
- * @returns {Object} The parser been loaded according to given name.
+ * @returns {Object} The parser been loaded according to given module name.
  */
 function getParserByName(name) {
-    var moduleName = util.format('../%s', name);
-    try {
-        return require(moduleName).parser;
-    } catch (err) {
-        var modulePath = path.normalize(__dirname + path.sep + moduleName + '.js');
-        throw new Error(util.format('Parser from module "%s" could not be loaded', modulePath));
+    var parser = parsersCache[name];
+    parser || parsersPath.split(':').some(function (dir) {
+        try {
+            /* jshint -W103,-W106 */
+            var prototype = require(path.join(path.resolve(absoluteBaseDir, dir), util.format('%s.js', name))).parser;
+            if (prototype.__proto__ === null) {
+                prototype.__proto__ = baseParser;  // make baseParser the object prototype
+            }
+            parser = Object.create(prototype);
+            parsersCache[name] = parser;
+            return true;
+        } catch (err) {
+            return false;
+        }
+    });
+    if (!parser) {
+        throw new Error(util.format('Parser from module "%s" could not be found at path %s', name, parsersPath));
     }
+    return parser;
 }
 
 

--- a/ngsi_adapter/src/lib/parsers/common/factory.js
+++ b/ngsi_adapter/src/lib/parsers/common/factory.js
@@ -57,7 +57,7 @@ function getParserByName(name) {
             /* jshint -W103,-W106 */
             var prototype = require(path.join(path.resolve(absoluteBaseDir, dir), util.format('%s.js', name))).parser;
             if (prototype.__proto__ === null) {
-                prototype.__proto__ = baseParser;  // make baseParser the object prototype
+                prototype.__proto__ = baseParser;  // ensure baseParser is part of the prototype chain
             }
             parser = Object.create(prototype);
             parsersCache[name] = parser;

--- a/ngsi_adapter/src/lib/parsers/nagios/check_disk.js
+++ b/ngsi_adapter/src/lib/parsers/nagios/check_disk.js
@@ -33,7 +33,7 @@
 /* jshint -W101, unused: false */
 
 
-var nagios = require('./common/nagios');
+var nagios = require('../common/nagios');
 
 
 /**

--- a/ngsi_adapter/src/lib/parsers/nagios/check_load.js
+++ b/ngsi_adapter/src/lib/parsers/nagios/check_load.js
@@ -33,7 +33,7 @@
 /* jshint -W101, unused: false */
 
 
-var nagios = require('./common/nagios');
+var nagios = require('../common/nagios');
 
 
 /**

--- a/ngsi_adapter/src/lib/parsers/nagios/check_mem.sh.js
+++ b/ngsi_adapter/src/lib/parsers/nagios/check_mem.sh.js
@@ -32,7 +32,7 @@
 /* jshint -W101, unused: false */
 
 
-var nagios = require('./common/nagios');
+var nagios = require('../common/nagios');
 
 
 /**

--- a/ngsi_adapter/src/lib/parsers/nagios/check_procs.js
+++ b/ngsi_adapter/src/lib/parsers/nagios/check_procs.js
@@ -17,15 +17,15 @@
 
 
 /**
- * Module that defines a parser for `check_users` Nagios plugin.
+ * Module that defines a parser for `check_procs` Nagios plugin.
  *
  * Context attributes to be calculated:
  *
- * - users = number of users logged in
+ * - procs = number of processes running
  *
- * @module check_users
- * @see https://www.nagios-plugins.org/doc/man/check_users.html
- * @see https://github.com/nagios-plugins/nagios-plugins/blob/maint/plugins/check_users.c
+ * @module check_procs
+ * @see https://www.nagios-plugins.org/doc/man/check_procs.html
+ * @see https://github.com/nagios-plugins/nagios-plugins/blob/maint/plugins/check_procs.c
  */
 
 
@@ -33,18 +33,18 @@
 /* jshint -W101, unused: false */
 
 
-var nagios = require('./common/nagios');
+var nagios = require('../common/nagios');
 
 
 /**
- * Parser for `check_users` Nagios probe.
+ * Parser for `check_procs` Nagios probe.
  * @augments nagios
  */
 var parser = Object.create(nagios.parser);
 
 
 /**
- * Parses `check_users` raw data to extract an object whose members are NGSI context attributes.
+ * Parses `check_procs` raw data to extract an object whose members are NGSI context attributes.
  *
  * @function getContextAttrs
  * @memberof parser
@@ -52,26 +52,23 @@ var parser = Object.create(nagios.parser);
  * @returns {Object} Context attributes.
  *
  * <code>
- * Sample data: "USERS OK - 1 users currently logged in |users=1;10;15;0"
- *                          ^                                  ^  ^  ^ ^
- *     # of users ----------+----------------------------------+  |  | |
- *     ==========                                                 |  | |
- *     Warning threshold -----------------------------------------+  | |
- *     Critical threshold -------------------------------------------+ |
- *     Reserved -------------------------------------------------------+
+ * Sample data: "PROCS OK: 136 processes"
+ *                 ^        ^
+ *     Metric -----+        |       (list of metrics: PROCS,VSZ,RSS,CPU,ELAPSED)
+ *     # of procs ----------+
  * </code>
  */
 parser.getContextAttrs = function(probeEntityData) {
     var data = probeEntityData.data.split('\n')[0];     // only consider first line of probe data, discard perfData
-    var attrs = { users: NaN };
+    var attrs = { procs: NaN };
 
-    var items = data.split('-');
+    var items = data.split(':');
     if (items[1]) {
-        attrs.users = parseFloat(items[1].trim().split(' ')[0]);
+        attrs.procs = parseFloat(items[1].trim().split(' ')[0]);
     }
 
-    if (isNaN(attrs.users)) {
-        throw new Error('No valid users data found');
+    if (isNaN(attrs.procs)) {
+        throw new Error('No valid procs data found');
     }
 
     return attrs;
@@ -79,6 +76,6 @@ parser.getContextAttrs = function(probeEntityData) {
 
 
 /**
- * Parser for `check_users`.
+ * Parser for `check_procs`.
  */
 exports.parser = parser;

--- a/ngsi_adapter/src/lib/parsers/nagios/check_users.js
+++ b/ngsi_adapter/src/lib/parsers/nagios/check_users.js
@@ -17,15 +17,15 @@
 
 
 /**
- * Module that defines a parser for `check_procs` Nagios plugin.
+ * Module that defines a parser for `check_users` Nagios plugin.
  *
  * Context attributes to be calculated:
  *
- * - procs = number of processes running
+ * - users = number of users logged in
  *
- * @module check_procs
- * @see https://www.nagios-plugins.org/doc/man/check_procs.html
- * @see https://github.com/nagios-plugins/nagios-plugins/blob/maint/plugins/check_procs.c
+ * @module check_users
+ * @see https://www.nagios-plugins.org/doc/man/check_users.html
+ * @see https://github.com/nagios-plugins/nagios-plugins/blob/maint/plugins/check_users.c
  */
 
 
@@ -33,18 +33,18 @@
 /* jshint -W101, unused: false */
 
 
-var nagios = require('./common/nagios');
+var nagios = require('../common/nagios');
 
 
 /**
- * Parser for `check_procs` Nagios probe.
+ * Parser for `check_users` Nagios probe.
  * @augments nagios
  */
 var parser = Object.create(nagios.parser);
 
 
 /**
- * Parses `check_procs` raw data to extract an object whose members are NGSI context attributes.
+ * Parses `check_users` raw data to extract an object whose members are NGSI context attributes.
  *
  * @function getContextAttrs
  * @memberof parser
@@ -52,23 +52,26 @@ var parser = Object.create(nagios.parser);
  * @returns {Object} Context attributes.
  *
  * <code>
- * Sample data: "PROCS OK: 136 processes"
- *                 ^        ^
- *     Metric -----+        |       (list of metrics: PROCS,VSZ,RSS,CPU,ELAPSED)
- *     # of procs ----------+
+ * Sample data: "USERS OK - 1 users currently logged in |users=1;10;15;0"
+ *                          ^                                  ^  ^  ^ ^
+ *     # of users ----------+----------------------------------+  |  | |
+ *     ==========                                                 |  | |
+ *     Warning threshold -----------------------------------------+  | |
+ *     Critical threshold -------------------------------------------+ |
+ *     Reserved -------------------------------------------------------+
  * </code>
  */
 parser.getContextAttrs = function(probeEntityData) {
     var data = probeEntityData.data.split('\n')[0];     // only consider first line of probe data, discard perfData
-    var attrs = { procs: NaN };
+    var attrs = { users: NaN };
 
-    var items = data.split(':');
+    var items = data.split('-');
     if (items[1]) {
-        attrs.procs = parseFloat(items[1].trim().split(' ')[0]);
+        attrs.users = parseFloat(items[1].trim().split(' ')[0]);
     }
 
-    if (isNaN(attrs.procs)) {
-        throw new Error('No valid procs data found');
+    if (isNaN(attrs.users)) {
+        throw new Error('No valid users data found');
     }
 
     return attrs;
@@ -76,6 +79,6 @@ parser.getContextAttrs = function(probeEntityData) {
 
 
 /**
- * Parser for `check_procs`.
+ * Parser for `check_users`.
  */
 exports.parser = parser;

--- a/ngsi_adapter/src/test/unit/test_adapter.js
+++ b/ngsi_adapter/src/test/unit/test_adapter.js
@@ -30,7 +30,8 @@
 process.argv = [];
 
 
-var util = require('util'),
+var url = require('url'),
+    util = require('util'),
     http = require('http'),
     dgram = require('dgram'),
     sinon = require('sinon'),
@@ -48,6 +49,7 @@ suite('adapter', function () {
 
     suiteSetup(function () {
         var self = this;
+        self.processEvents = ['SIGINT', 'SIGTERM', 'uncaughtException', 'exit'];
         self.baseurl = 'http://hostname:1234';
         self.resource = 'check_load';
         self.body = 'invalid load data';
@@ -99,6 +101,7 @@ suite('adapter', function () {
     teardown(function () {
         delete this.request;
         this.udpServer.removeAllListeners();
+        this.processEvents.map(function (event) { process.removeListener(event, process.listeners(event).pop()); });
     });
 
     test('request_fails_if_not_post_method', function () {
@@ -160,6 +163,29 @@ suite('adapter', function () {
         self.httpListener(self.request, response);
         assert(response.writeHead.calledOnce);
         assert.equal(response.writeHead.args[0][0], 200);  // ok
+    });
+
+    test('request_fails_when_domain_error', function (done) {
+        var self = this;
+        var response = {
+            writeHead: function () {},
+            end: sinon.stub()
+        };
+        // Force an error when invoking url.parse()
+        sinon.stub(url, 'parse', function () {
+            url.parse.restore();
+            self.request.emit('error', new Error('detail of error'));
+            return url.parse.apply(null, arguments);
+        });
+        // Ensure a HTTP 500 status in response
+        sinon.stub(response, 'writeHead', function (status) {
+            response.writeHead.restore();
+            assert.equal(status, 500);
+            done();
+        });
+        self.timeout(500);
+        self.request.url = self.baseurl + '/' + self.resource + '?id=id&type=type';
+        self.httpListener(self.request, response);
     });
 
     test('request_asynchronous_callback_error_on_invalid_resource_data', function (done) {

--- a/ngsi_adapter/src/test/unit/test_adapter.js
+++ b/ngsi_adapter/src/test/unit/test_adapter.js
@@ -141,6 +141,18 @@ suite('adapter', function () {
         assert.equal(response.writeHead.args[0][0], 400);  // bad request
     });
 
+    test('request_fails_missing_url_resource', function () {
+        var self = this;
+        var response = {
+            writeHead: sinon.stub(),
+            end: sinon.stub()
+        };
+        self.request.url = self.baseurl + '/' + '?id=id&type=type';
+        self.httpListener(self.request, response);
+        assert(response.writeHead.calledOnce);
+        assert.equal(response.writeHead.args[0][0], 404);  // not found
+    });
+
     test('request_fails_unknown_url_resource', function () {
         var self = this;
         var response = {


### PR DESCRIPTION
#### Reviewers
@flopezag 

#### Description
Implement a configurable directory search path for additional custom parsers (e.g. for Monasca or Ceilometer integration using UDP requests).

#### Testing
Verified.