### PR TITLE
Add option to set maximum number of simultaneous outgoing requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ For more information, please refer to the description of Monitoring GE in
 
 ## Releases
 
+[FIWARE 3.5.2 (R8)][release_3_5_2_ref]
+
+* ngsi_event_broker version 1.3.2
+* ngsi_adapter version 1.1.7
+
 [FIWARE 3.5.2 (R7)][release_3_5_2_ref]
 
 * ngsi_event_broker version 1.3.2

--- a/ngsi_adapter/README.md
+++ b/ngsi_adapter/README.md
@@ -69,6 +69,10 @@ two components: probe data and optional performance data.
 
 ## Changelog
 
+Version 1.1.7
+
+* Add option to set maximum number of simultaneous outgoing requests
+
 Version 1.1.6
 
 * Fix bug in quantum-openvswitch-agent parser

--- a/ngsi_adapter/script/build/files/debian/changelog
+++ b/ngsi_adapter/script/build/files/debian/changelog
@@ -1,3 +1,9 @@
+fiware-monitoring-ngsi-adapter (1.1.7) precise; urgency=low
+
+  * Add option to set maximum number of simultaneous outgoing requests
+
+ -- Telefónica I+D <opensource@tid.es>  Tue, 24 Nov 2015 18:00:00 +0200
+
 fiware-monitoring-ngsi-adapter (1.1.6) precise; urgency=low
 
   * Fixed bug in quantum-openvswitch-agent parser

--- a/ngsi_adapter/script/build/files/redhat/SPECS/fiware-monitoring-ngsi-adapter.spec
+++ b/ngsi_adapter/script/build/files/redhat/SPECS/fiware-monitoring-ngsi-adapter.spec
@@ -189,6 +189,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Tue Nov 24 2015 Telefónica I+D <opensource@tid.es> 1.1.7-1
+- Add option to set maximum number of simultaneous outgoing requests
+
 * Tue Jun 02 2015 Telefónica I+D <opensource@tid.es> 1.1.6-1
 - Fix bug in quantum-openvswitch-agent parser
 

--- a/ngsi_adapter/src/config/options.js
+++ b/ngsi_adapter/src/config/options.js
@@ -32,13 +32,15 @@
  * @property {String} defaults.brokerUrl    Default Context Broker URL.
  * @property {String} defaults.listenHost   Default adapter listen host.
  * @property {Number} defaults.listenPort   Default adapter listen port.
+ * @property {Number} defaults.maxRequests  Default maximum number of simultaneous outgoing requests.
  * @property {Number} defaults.retries      Default maximum number of invocation retries.
  */
 var defaults = {
-    brokerUrl:  'http://127.0.0.1:1026/',
-    listenHost: '127.0.0.1',
-    listenPort: 1337,
-    retries:    2
+    brokerUrl:   'http://127.0.0.1:1026/',
+    listenHost:  '127.0.0.1',
+    listenPort:  1337,
+    maxRequests: 5,
+    retries:     2
 };
 
 
@@ -48,14 +50,16 @@ var defaults = {
  * @property {String} opts.brokerUrl        Context Broker URL.
  * @property {String} opts.listenHost       Adapter listen host.
  * @property {Number} opts.listenPort       Adapter listen port.
+ * @property {Number} opts.maxRequests      Maximum number of simultaneous outgoing requests.
  * @property {Number} opts.retries          Maximum number of invocation retries.
  */
 var opts = require('optimist')
-    .options('b', { alias: 'brokerUrl',  'default': defaults.brokerUrl,  describe: 'Context Broker URL'  })
-    .options('H', { alias: 'listenHost', 'default': defaults.listenHost, describe: 'Adapter listen host' })
-    .options('p', { alias: 'listenPort', 'default': defaults.listenPort, describe: 'Adapter listen port' })
-    .options('r', { alias: 'retries',    'default': defaults.retries,    describe: 'Maximum retries'     })
-    .options('h', { alias: 'help',       'boolean': true,                describe: 'Show help'           })
+    .options('b', { alias: 'brokerUrl',   'default': defaults.brokerUrl,   describe: 'Context Broker URL'            })
+    .options('H', { alias: 'listenHost',  'default': defaults.listenHost,  describe: 'Adapter listen host'           })
+    .options('p', { alias: 'listenPort',  'default': defaults.listenPort,  describe: 'Adapter listen port'           })
+    .options('m', { alias: 'maxRequests', 'default': defaults.maxRequests, describe: 'Maximum simultaneous requests' })
+    .options('r', { alias: 'retries',     'default': defaults.retries,     describe: 'Maximum retries'               })
+    .options('h', { alias: 'help',        'boolean': true,                 describe: 'Show help'                     })
     .demand([]);
 
 

--- a/ngsi_adapter/src/lib/adapter.js
+++ b/ngsi_adapter/src/lib/adapter.js
@@ -37,6 +37,12 @@ var http   = require('http'),
 
 
 /**
+ * Restrict the number of simultaneous outgoing requests.
+ */
+http.globalAgent.maxSockets = opts.maxRequests;
+
+
+/**
  * Asynchronously process POST requests and then invoke updateContext() on ContextBroker.
  *
  * @param {http.IncomingMessage} request    The request to this server.

--- a/ngsi_adapter/src/package.json
+++ b/ngsi_adapter/src/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.6",
+  "version": "1.1.7",
   "name": "ngsi_adapter",
   "main": "lib/adapter.js",
   "description": "Generic NGSI Probe Adapter",


### PR DESCRIPTION
#### Reviewers
@jesuspg @jframos 

#### Description
Add option `--maxRequests` in order to adjust (sometimes, increase) the maximum number of simultaneous requests to ContextBroker (this is a fine-tuning option for advanced users).

#### Testing
Verified.