### PR TITLE
Add option to set maximum number of simultaneous outgoing requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,9 @@ The configuration used by the adapter service is optionally read from the file
     # ADAPTER_BROKER_URL - The endpoint where Context Broker is listening
     ADAPTER_BROKER_URL=http://127.0.0.1:1026/
 
+    # ADAPTER_MAX_REQUESTS - Maximum number of simultaneous requests
+    ADAPTER_MAX_REQUESTS=5
+
     # ADAPTER_RETRIES - Maximum number of retries invoking Context Broker
     ADAPTER_RETRIES=2
 
@@ -234,6 +237,7 @@ Most of these attributes map to options of the `command line interface
 - ``ADAPTER_UDP_ENDPOINTS`` maps to ``-u`` or ``--udpEndpoints`` option
 - ``ADAPTER_PARSERS_PATH`` maps to ``-P`` or ``--parsersPath`` option
 - ``ADAPTER_BROKER_URL`` maps to ``-b`` or ``--brokerUrl`` option
+- ``ADAPTER_MAX_REQUESTS`` maps to ``-m`` or ``--maxRequests`` option
 - ``ADAPTER_RETRIES`` maps to ``-r`` or ``--retries`` option
 
 Default values are found in ``/opt/fiware/ngsi_adapter/lib/common.js``.

--- a/doc/manuals/admin/README.rst
+++ b/doc/manuals/admin/README.rst
@@ -172,6 +172,8 @@ You can use these command line options (available typing ``adapter --help``):
    Colon-separated path with directories to look for parsers
 -b, --brokerUrl
    The URL of the Context Broker instance to publish data to
+-m, --maxRequests
+   Maximum number of simultaneous outgoing requests to Context Broker
 -r, --retries
    Number of times a request to Context Broker is retried, in case of error
 

--- a/ngsi_adapter/README.rst
+++ b/ngsi_adapter/README.rst
@@ -24,6 +24,7 @@ Changelog
 
 Version 1.3.0
 
+- Add option to set maximum number of simultaneous outgoing requests
 - Add an option to specify a list of directories to look for parsers
 - Add support to UDP requests
 

--- a/ngsi_adapter/script/build/files/debian/changelog
+++ b/ngsi_adapter/script/build/files/debian/changelog
@@ -1,8 +1,9 @@
 fiware-monitoring-ngsi-adapter (1.3.0) precise; urgency=low
+  * Add option to set maximum number of simultaneous outgoing requests
   * Add an option to specify a list of directories to look for parsers
   * Add support to UDP requests
 
- -- Telefónica I+D <opensource@tid.es>  Fri, 20 Nov 2015 18:00:00 +0200
+ -- Telefónica I+D <opensource@tid.es>  Tue, 24 Nov 2015 18:00:00 +0200
 
 fiware-monitoring-ngsi-adapter (1.2.4) precise; urgency=low
 

--- a/ngsi_adapter/script/build/files/debian/ngsi_adapter.default
+++ b/ngsi_adapter/script/build/files/debian/ngsi_adapter.default
@@ -18,5 +18,8 @@ ADAPTER_PARSERS_PATH=lib/parsers/nagios
 # ADAPTER_BROKER_URL - The endpoint where Context Broker is listening
 ADAPTER_BROKER_URL=http://127.0.0.1:1026/
 
+# ADAPTER_MAX_REQUESTS - Maximum number of simultaneous requests
+ADAPTER_MAX_REQUESTS=5
+
 # ADAPTER_RETRIES - Maximum number of retries invoking Context Broker
 ADAPTER_RETRIES=2

--- a/ngsi_adapter/script/build/files/redhat/SOURCES/etc/sysconfig/ngsi_adapter
+++ b/ngsi_adapter/script/build/files/redhat/SOURCES/etc/sysconfig/ngsi_adapter
@@ -18,5 +18,8 @@ ADAPTER_PARSERS_PATH=lib/parsers/nagios
 # ADAPTER_BROKER_URL - The endpoint where Context Broker is listening
 ADAPTER_BROKER_URL=http://127.0.0.1:1026/
 
+# ADAPTER_MAX_REQUESTS - Maximum number of simultaneous requests
+ADAPTER_MAX_REQUESTS=5
+
 # ADAPTER_RETRIES - Maximum number of retries invoking Context Broker
 ADAPTER_RETRIES=2

--- a/ngsi_adapter/script/build/files/redhat/SPECS/fiware-monitoring-ngsi-adapter.spec
+++ b/ngsi_adapter/script/build/files/redhat/SPECS/fiware-monitoring-ngsi-adapter.spec
@@ -187,7 +187,8 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Fri Nov 20 2015 Telefónica I+D <opensource@tid.es> 1.3.0-1
+* Tue Nov 24 2015 Telefónica I+D <opensource@tid.es> 1.3.0-1
+- Add option to set maximum number of simultaneous outgoing requests
 - Add an option to specify a list of directories to look for parsers
 - Add support to UDP requests
 

--- a/ngsi_adapter/src/config/options.js
+++ b/ngsi_adapter/src/config/options.js
@@ -38,6 +38,7 @@ var defaults = require('../lib/common').defaults;
  * @property {Number} opts.listenPort       Adapter listen HTTP port.
  * @property {String} opts.udpEndpoints     Comma-separated list of UDP endpoints (host:port:parser).
  * @property {String} opts.parsersPath      Colon-separated path with directories to look for parsers.
+ * @property {Number} opts.maxRequests      Maximum number of simultaneous outgoing requests.
  * @property {Number} opts.retries          Maximum number of Context Broker invocation retries.
  */
 var opts = require('optimist')
@@ -65,6 +66,10 @@ var opts = require('optimist')
         alias: 'brokerUrl',
         'default': process.env['ADAPTER_BROKER_URL'] || defaults.brokerUrl,
         describe: 'Context Broker URL'
+    }).options('m', {
+        alias: 'maxRequests',
+        'default': process.env['ADAPTER_MAX_REQUESTS'] || defaults.maxRequests,
+        describe: 'Maximum simultaneous requests'
     }).options('r', {
         alias: 'retries',
         'default': process.env['ADAPTER_RETRIES'] || defaults.retries,

--- a/ngsi_adapter/src/lib/adapter.js
+++ b/ngsi_adapter/src/lib/adapter.js
@@ -42,6 +42,12 @@ var http = require('http'),
 
 
 /**
+ * Restrict the number of simultaneous outgoing requests.
+ */
+http.globalAgent.maxSockets = opts.maxRequests;
+
+
+/**
  * Asynchronously process incoming requests and then invoke updateContext() on ContextBroker.
  *
  * @param {Domain}          reqdomain  Domain handling request (includes context, timestamp, id, type, body & parser).

--- a/ngsi_adapter/src/lib/common.js
+++ b/ngsi_adapter/src/lib/common.js
@@ -43,6 +43,7 @@ exports.txIdHttpHeader = 'txId';
  * @property {Number} defaults.listenPort   Default adapter HTTP listen port.
  * @property {String} defaults.udpEndpoints Default list of UDP endpoints (host:port:parser).
  * @property {String} defaults.parsersPath  Default path with directories to look for parsers.
+ * @property {Number} defaults.maxRequests  Default maximum number of simultaneous outgoing requests.
  * @property {Number} defaults.retries      Default maximum number of Context Broker invocation retries.
  */
 exports.defaults = {
@@ -52,5 +53,6 @@ exports.defaults = {
     listenPort: 1337,
     udpEndpoints: null,
     parsersPath: 'lib/parsers:lib/parsers/nagios',
+    maxRequests: 5,
     retries: 2
 };


### PR DESCRIPTION
#### Reviewers
@flopezag 

#### Description
Add option ``--maxRequests`` in order to adjust (sometimes, increase) the maximum number of simultaneous requests to ContextBroker (this is a fine-tuning option for advanced users).

#### Testing
Verified.