### PR TITLE
Feature/ngsi requests json format

### DIFF
--- a/ngsi_adapter/lib/adapter.js
+++ b/ngsi_adapter/lib/adapter.js
@@ -64,7 +64,7 @@ function updateContext(reqdomain, callback) {
             updateReqOpts = {
                 hostname: remoteUrl.hostname,
                 port: remoteUrl.port,
-                path: '/v1/contextEntities',
+                path: '/v1/updateContext',
                 method: 'POST',
                 headers: {
                    'Accept': updateReqType,

--- a/ngsi_adapter/lib/adapter.js
+++ b/ngsi_adapter/lib/adapter.js
@@ -64,7 +64,7 @@ function updateContext(reqdomain, callback) {
             updateReqOpts = {
                 hostname: remoteUrl.hostname,
                 port: remoteUrl.port,
-                path: '/NGSI10/updateContext',
+                path: '/v1/contextEntities',
                 method: 'POST',
                 headers: {
                    'Accept': updateReqType,

--- a/ngsi_adapter/lib/parsers/common/base.js
+++ b/ngsi_adapter/lib/parsers/common/base.js
@@ -138,15 +138,12 @@ baseParser.getUpdateContextJSON = function (id, type, attrs) {
     };
 
     for (var name in attrs) {
-        var next = {
+        payload.contextElements[0].attributes.push({
             'name': name,
             'type': 'string',
             'value': attrs[name].toString()
-        };
-        payload.contextElements[0].attributes.push( next );
+        });
     }
-
-    console.log(JSON.stringify(payload));
 
     return JSON.stringify(payload);
 };

--- a/ngsi_adapter/lib/parsers/common/base.js
+++ b/ngsi_adapter/lib/parsers/common/base.js
@@ -144,7 +144,7 @@ baseParser.getUpdateContextJSON = function (id, type, attrs) {
     result += '        }';
     result += lastComma;
         }
-    result = result.substring(0, result.length-lastComma.length)+'\n';
+    result = result.substring(0, result.length - lastComma.length) + '\n';
     result += '    ]\n';
     }
 

--- a/ngsi_adapter/lib/parsers/common/base.js
+++ b/ngsi_adapter/lib/parsers/common/base.js
@@ -53,7 +53,7 @@ baseParser.timestampAttrName = '_timestamp';
  * @returns {String} The content type (the format) for Context Broker requests.
  */
 baseParser.getContentType = function () {
-    return 'application/xml';
+    return 'application/json';
 };
 
 
@@ -126,7 +126,31 @@ baseParser.getContextAttrs = function (data) {
  * @returns {String} The request body in JSON format.
  */
 baseParser.getUpdateContextJSON = function (id, type, attrs) {
-    throw new Error('TO-DO');
+    var result = '';
+    var lastComma = ',\n';
+
+    result += '{\n';
+    result += '    "id": "' + id + '",\n';
+    result += '    "isPattern": "false",\n';
+    result += '    "type": "' + type + '",\n';
+
+    if (Object.keys(attrs).length > 0) {
+    result += '    "attributes": [\n';
+        for (var name in attrs) {
+    result += '        {\n';
+    result += '            "name": "' + name + '",\n';
+    result += '            "type": "' + 'string' + '",\n';
+    result += '            "value": "' + attrs[name] + '"\n';
+    result += '        }';
+    result += lastComma;
+        }
+    result = result.substring(0, result.length-lastComma.length)+'\n';
+    result += '    ]\n';
+    }
+
+    result += '}\n';
+
+    return result;
 };
 
 

--- a/ngsi_adapter/lib/parsers/common/base.js
+++ b/ngsi_adapter/lib/parsers/common/base.js
@@ -64,7 +64,7 @@ baseParser.getContentType = function () {
  * @memberof baseParser
  * @this baseParser
  * @param {Domain} reqdomain   Domain handling current request (includes context, timestamp, id, type, body & parser).
- * @returns {String} The request body, either in XML or JSON format.
+ * @returns {String} The request body in JSON format.
  */
 baseParser.updateContextRequest = function (reqdomain) {
     var entityData = this.parseRequest(reqdomain),

--- a/ngsi_adapter/lib/parsers/common/base.js
+++ b/ngsi_adapter/lib/parsers/common/base.js
@@ -141,7 +141,7 @@ baseParser.getUpdateContextJSON = function (id, type, attrs) {
         var next = {
             'name': name,
             'type': 'string',
-            'value': attrs[name]
+            'value': attrs[name].toString()
         };
         payload.contextElements[0].attributes.push( next );
     }

--- a/ngsi_adapter/lib/parsers/common/base.js
+++ b/ngsi_adapter/lib/parsers/common/base.js
@@ -81,9 +81,7 @@ baseParser.updateContextRequest = function (reqdomain) {
     // feature #4: automatically add request timestamp to entity attributes
     entityAttrs[this.timestampAttrName] = reqdomain.timestamp;
 
-    return (this.getContentType() === 'application/xml') ?
-        this.getUpdateContextXML(entityId, entityType, entityAttrs) :
-        this.getUpdateContextJSON(entityId, entityType, entityAttrs);
+    return this.getUpdateContextJSON(entityId, entityType, entityAttrs);
 };
 
 
@@ -126,67 +124,31 @@ baseParser.getContextAttrs = function (data) {
  * @returns {String} The request body in JSON format.
  */
 baseParser.getUpdateContextJSON = function (id, type, attrs) {
-    var result = '';
-    var lastComma = ',\n';
 
-    result += '{\n';
-    result += '    "id": "' + id + '",\n';
-    result += '    "isPattern": "false",\n';
-    result += '    "type": "' + type + '",\n';
+    var payload = {
+        'contextElements': [
+            {
+                'type': type,
+                'isPattern': 'false',
+                'id': id,
+                'attributes': [ ]
+            }
+        ],
+        'updateAction': 'APPEND'
+    };
 
-    if (Object.keys(attrs).length > 0) {
-    result += '    "attributes": [\n';
-        for (var name in attrs) {
-    result += '        {\n';
-    result += '            "name": "' + name + '",\n';
-    result += '            "type": "' + 'string' + '",\n';
-    result += '            "value": "' + attrs[name] + '"\n';
-    result += '        }';
-    result += lastComma;
-        }
-    result = result.substring(0, result.length - lastComma.length) + '\n';
-    result += '    ]\n';
-    }
-
-    result += '}\n';
-
-    return result;
-};
-
-
-/**
- * Generates a XML updateContext() request body.
- *
- * @function getUpdateContextXML
- * @memberof baseParser
- * @param {String} id          The entity identifier.
- * @param {String} type        The entity type.
- * @param {Object} attrs       The entity context attributes.
- * @returns {String} The request body in XML format.
- */
-baseParser.getUpdateContextXML = function (id, type, attrs) {
-    var result = '';
-    result += '<?xml version="1.0" encoding="UTF-8"?>\n';
-    result += '<updateContextRequest>\n';
-    result += '    <contextElementList>\n';
-    result += '        <contextElement>\n';
-    result += '            <entityId type="' + type + '" isPattern="false">\n';
-    result += '                <id>' + id + '</id>\n';
-    result += '            </entityId>\n';
-    result += '            <contextAttributeList>\n';
     for (var name in attrs) {
-    result += '                <contextAttribute>\n';
-    result += '                    <name>' + name + '</name>\n';
-    result += '                    <type>string</type>\n';
-    result += '                    <contextValue>' + attrs[name] + '</contextValue>\n';
-    result += '                </contextAttribute>\n';
+        var next = {
+            'name': name,
+            'type': 'string',
+            'value': attrs[name]
+        };
+        payload.contextElements[0].attributes.push( next );
     }
-    result += '            </contextAttributeList>\n';
-    result += '        </contextElement>\n';
-    result += '    </contextElementList>\n';
-    result += '    <updateAction>APPEND</updateAction>\n';
-    result += '</updateContextRequest>\n';
-    return result;
+
+    console.log(JSON.stringify(payload));
+
+    return JSON.stringify(payload);
 };
 
 

--- a/ngsi_adapter/test/unit/common.js
+++ b/ngsi_adapter/test/unit/common.js
@@ -53,20 +53,19 @@ function assertValidUpdateJSON(updateJSON, testSuite) {
     // feature #4: automatically add request timestamp to entity attributes
     assert.ok(testSuite.entityData[timestamp]);
     assertIsNumber(testSuite.entityId);
-    var entityAttrList = Object.keys(testSuite.entityData);
     var update = JSON.parse(updateJSON);
     // check id element
     assert.ok(update);
     assert.ok(update.id);
     // check isPattern element
-    assert.ok(update.isPattern === "false");
+    assert.ok(update.isPattern === 'false');
     // check type element
     assert.ok(update.type);
     // check attributes
-    update.attributes.forEach(function(item) { 
-        assert.ok(item['name']);
-        assert.ok(item['type']);
-        assert.ok(item['value']);
+    update.attributes.forEach(function(item) {
+        assert.ok(item.name);
+        assert.ok(item.type);
+        assert.ok(item.value);
     });
 }
 

--- a/ngsi_adapter/test/unit/common.js
+++ b/ngsi_adapter/test/unit/common.js
@@ -56,17 +56,18 @@ function assertValidUpdateJSON(updateJSON, testSuite) {
     var update = JSON.parse(updateJSON);
     // check id element
     assert.ok(update);
-    assert.ok(update.id);
+    assert.ok(update.contextElements[0].id);
     // check isPattern element
-    assert.ok(update.isPattern === 'false');
+    assert.ok(update.contextElements[0].isPattern === 'false');
     // check type element
-    assert.ok(update.type);
+    assert.ok(update.contextElements[0].type);
     // check attributes
-    update.attributes.forEach(function(item) {
+    update.contextElements[0].attributes.forEach(function(item) {
         assert.ok(item.name);
         assert.ok(item.type);
         assert.ok(item.value);
     });
+    assert.ok(update.updateAction === 'APPEND');
 }
 
 /**

--- a/ngsi_adapter/test/unit/common.js
+++ b/ngsi_adapter/test/unit/common.js
@@ -77,6 +77,6 @@ exports.assertIsNumber = assertIsNumber;
 
 
 /**
- * assertValidUpdateXML.
+ * assertValidUpdateJSON.
  */
 exports.assertValidUpdateJSON = assertValidUpdateJSON;

--- a/ngsi_adapter/test/unit/common.js
+++ b/ngsi_adapter/test/unit/common.js
@@ -27,7 +27,6 @@
 
 
 var assert = require('assert'),
-    xml2js = require('xml2js'),
     timestamp = require('../../lib/parsers/common/base').parser.timestampAttrName;
 
 
@@ -41,50 +40,35 @@ function assertIsNumber(value) {
     assert(!isNaN(value) && !isNaN(parseFloat(value)));
 }
 
-
 /**
- * Asserts given XML is well formed according to test suite data.
+ * Asserts given JSON is well formed according to test suite data.
  *
- * @function assertValidUpdateXML
- * @param {String} updateXML    The XML payload of an updateContext request.
- * @param {Object} testSuite    The test suite whose data produced the XML.
+ * @function assertValidUpdateJSON
+ * @param {String} updateJSON   The JSON payload of an updateContext request.
+ * @param {Object} testSuite    The test suite whose data produced the JSON.
  */
-function assertValidUpdateXML(updateXML, testSuite) {
-    assert.ok(updateXML);
+function assertValidUpdateJSON(updateJSON, testSuite) {
     assert.ok(testSuite.entityType);
     assert.ok(testSuite.entityData);
     // feature #4: automatically add request timestamp to entity attributes
     assert.ok(testSuite.entityData[timestamp]);
     assertIsNumber(testSuite.entityId);
     var entityAttrList = Object.keys(testSuite.entityData);
-    xml2js.parseString(updateXML, function(err, result) {
-        // check <updateContextRequest> element
-        assert.ok(result.updateContextRequest);
-        // check <contextElementList> element
-        assert.ok(result.updateContextRequest.contextElementList);
-        assert(result.updateContextRequest.contextElementList.length > 0);
-        // check <contextElement> element
-        var contextElement = result.updateContextRequest.contextElementList[0].contextElement[0];
-        assert.ok(contextElement);
-        // check <entityId> element and its attributes/subelements
-        assert.ok(contextElement.entityId);
-        assert.equal(contextElement.entityId[0].$.type, testSuite.entityType);
-        assert.equal(contextElement.entityId[0].id[0], testSuite.entityId);
-        // check <contextAttributeList> element
-        assert(contextElement.contextAttributeList.length === 1);
-        var contextAttrList = contextElement.contextAttributeList[0].contextAttribute;
-        assert.ok(contextAttrList);
-        // ensure element has one and only one subelement corresponding to expected attributes
-        var attrcount = {};
-        entityAttrList.forEach(function(item) { attrcount[item] = 0; });
-        contextAttrList.forEach(function(item) { attrcount[item.name[0]]++; });
-        assert.equal(Object.keys(attrcount).length, entityAttrList.length);
-        entityAttrList.forEach(function(item) { assert(attrcount[item] === 1); });
-        // ensure subelements are numbers
-        contextAttrList.forEach(function(item) { assertIsNumber(item.contextValue[0]); });
+    var update = JSON.parse(updateJSON);
+    // check id element
+    assert.ok(update);
+    assert.ok(update.id);
+    // check isPattern element
+    assert.ok(update.isPattern === "false");
+    // check type element
+    assert.ok(update.type);
+    // check attributes
+    update.attributes.forEach(function(item) { 
+        assert.ok(item['name']);
+        assert.ok(item['type']);
+        assert.ok(item['value']);
     });
 }
-
 
 /**
  * assertIsNumber.
@@ -95,4 +79,4 @@ exports.assertIsNumber = assertIsNumber;
 /**
  * assertValidUpdateXML.
  */
-exports.assertValidUpdateXML = assertValidUpdateXML;
+exports.assertValidUpdateJSON = assertValidUpdateJSON;

--- a/ngsi_adapter/test/unit/test_base_parser.js
+++ b/ngsi_adapter/test/unit/test_base_parser.js
@@ -109,7 +109,7 @@ suite('base_parser', function () {
         parser.parseRequest = sinon.spy(function () { return {}; });
         parser.getContextAttrs = sinon.spy(function () { return self.entityData; });
         var update = parser.updateContextRequest(self.reqdomain);
-        common.assertValidUpdateXML(update, self);
+        common.assertValidUpdateJSON(update, self);
     });
 
 });

--- a/ngsi_adapter/test/unit/test_check_disk.js
+++ b/ngsi_adapter/test/unit/test_check_disk.js
@@ -121,7 +121,7 @@ suite('check_disk', function () {
         );
         var parser = this.factory.getParser(this.request);
         var update = parser.updateContextRequest(this.reqdomain);
-        common.assertValidUpdateXML(update, this);
+        common.assertValidUpdateJSON(update, this);
     });
 
     test('parse_ok_free_space_percentage', function () {

--- a/ngsi_adapter/test/unit/test_check_load.js
+++ b/ngsi_adapter/test/unit/test_check_load.js
@@ -95,7 +95,7 @@ suite('check_load', function () {
         this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
         var update = parser.updateContextRequest(this.reqdomain);
-        common.assertValidUpdateXML(update, this);
+        common.assertValidUpdateJSON(update, this);
     });
 
     test('parse_ok_cpu_load_percentage', function () {

--- a/ngsi_adapter/test/unit/test_check_mem.sh.js
+++ b/ngsi_adapter/test/unit/test_check_mem.sh.js
@@ -91,7 +91,7 @@ suite('check_mem.sh', function () {
         this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
         var update = parser.updateContextRequest(this.reqdomain);
-        common.assertValidUpdateXML(update, this);
+        common.assertValidUpdateJSON(update, this);
     });
 
     test('parse_ok_used_mem_percentage', function () {

--- a/ngsi_adapter/test/unit/test_check_procs.js
+++ b/ngsi_adapter/test/unit/test_check_procs.js
@@ -90,14 +90,14 @@ suite('check_procs', function () {
         this.reqdomain.body = util.format('%s', this.probeBody.data);
         var parser = this.factory.getParser(this.request);
         var update = parser.updateContextRequest(this.reqdomain);
-        common.assertValidUpdateXML(update, this);
+        common.assertValidUpdateJSON(update, this);
     });
 
     test('get_update_request_ok_with_another_threshold_metric', function () {
         this.reqdomain.body = util.format('%s', this.probeBody.data).replace(/^PROCS/, 'VSZ');
         var parser = this.factory.getParser(this.request);
         var update = parser.updateContextRequest(this.reqdomain);
-        common.assertValidUpdateXML(update, this);
+        common.assertValidUpdateJSON(update, this);
     });
 
     test('parse_ok_number_of_procs', function () {

--- a/ngsi_adapter/test/unit/test_check_users.js
+++ b/ngsi_adapter/test/unit/test_check_users.js
@@ -91,7 +91,7 @@ suite('check_users', function () {
         this.reqdomain.body = util.format('%s|%s', this.probeBody.data, this.probeBody.perf);
         var parser = this.factory.getParser(this.request);
         var update = parser.updateContextRequest(this.reqdomain);
-        common.assertValidUpdateXML(update, this);
+        common.assertValidUpdateJSON(update, this);
     });
 
     test('parse_ok_number_of_users_logged_in', function () {


### PR DESCRIPTION
#### Reviewers
@pratid

#### Description
Send context update requests to Orion in JSON format instead of XML. This is because Orion no longer supports XML.

#### Testing
grunt test - all passing
grunt lint - all passing
XML parsing test cases updated to verify JSON