### PR TITLE
Fix path to invoke CB and error processing of the response

### DIFF
--- a/ngsi_adapter/test/unit/test_adapter.js
+++ b/ngsi_adapter/test/unit/test_adapter.js
@@ -278,7 +278,7 @@ suite('adapter', function () {
             serverResponse.setEncoding = sinon.stub();
             serverResponse.statusCode = 200;
             callback(serverResponse);
-            serverResponse.emit('data');
+            serverResponse.emit('data', '{"key": "value"}');
             serverResponse.emit('end');
             clientRequest.end = sinon.stub();
             return clientRequest;
@@ -418,14 +418,14 @@ suite('adapter', function () {
             serverResponse.setEncoding = sinon.stub();
             serverResponse.statusCode = 200;
             callback(serverResponse);
-            serverResponse.emit('data');
+            serverResponse.emit('data', '{"key": "value"}');
             serverResponse.emit('end');
             clientRequest.end = sinon.stub();
             httpRequest.restore();
             factoryGetParserByName.restore();
             done();
         });
-        this.timeout(500);
+        self.timeout(500);
         client.send(message, 0, message.length, self.udpPort, self.udpHost, function (err, bytes) {
             client.close();
             assert.equal(err, null);


### PR DESCRIPTION
#### Reviewers
@flopezag 

#### Description
In order to keep backwards compatibility with older releases of Context Broker, the API path `/NGSI10` is still used. Besides, response status code is taken from body payload (according to such API).

#### Testing
Verified in FIWARE Lab.