### PR TITLE
Add support to node.js 4.x and 6.x as prerequisite

### DIFF
--- a/ngsi_adapter/tools/build/files/debian/copyright
+++ b/ngsi_adapter/tools/build/files/debian/copyright
@@ -3,11 +3,11 @@ Upstream-Name: fiware-monitoring-ngsi-adapter
 Source: https://github.com/telefonicaid/fiware-monitoring/tree/master/ngsi_adapter
 
 Files: *
-Copyright: 2013-2015 Telefónica I+D <opensource@tid.es>
+Copyright: 2013-2016 Telefónica I+D <opensource@tid.es>
 License: Apache-2.0
 
 Files: debian/*
-Copyright: 2013-2015 Telefónica I+D <opensource@tid.es>
+Copyright: 2013-2016 Telefónica I+D <opensource@tid.es>
 License: Apache-2.0
 
 License: Apache-2.0

--- a/ngsi_adapter/tools/build/files/debian/install
+++ b/ngsi_adapter/tools/build/files/debian/install
@@ -4,4 +4,3 @@ README.rst /opt/fiware/ngsi_adapter
 package.json /opt/fiware/ngsi_adapter
 .npmrc /opt/fiware/ngsi_adapter
 lib/* /opt/fiware/ngsi_adapter/lib
-config/* /opt/fiware/ngsi_adapter/config

--- a/ngsi_adapter/tools/build/files/debian/ngsi_adapter.init
+++ b/ngsi_adapter/tools/build/files/debian/ngsi_adapter.init
@@ -1,5 +1,4 @@
-#!/bin/sh
-set -a
+#!/bin/sh -a
 
 ### BEGIN INIT INFO
 # Provides:          ngsi_adapter

--- a/ngsi_adapter/tools/build/files/debian/preinst
+++ b/ngsi_adapter/tools/build/files/debian/preinst
@@ -25,13 +25,15 @@ setup_nodesource() {
 
 	# prepare sources list configuration for the next `apt-get' command
 	# and DO NOT run `apt-get update' within this script (due to locking)
-	curl -sL https://deb.nodesource.com/setup \
+	MAJOR=${NODE_REQ_VERSION%%.*}
+	MINOR=$(expr ${NODE_REQ_VERSION%.*} : '0\.\(.*\)' '|' 'x')
+	curl -sL https://deb.nodesource.com/setup_$MAJOR.$MINOR \
 	| grep -v "apt-get update" \
 	| bash - >/dev/null
 	if [ $? -eq 0 ]; then fmt --width=${COLUMNS:-$(tput cols)} 1>&2 <<-EOF
 
-		Please run \`sudo apt-get update && sudo apt-get -y install nodejs'
-		to upgrade version prior reinstalling the package.
+		Please run \`apt-get update && apt-get -y install nodejs' to
+		upgrade version prior reinstalling the package.
 
 		EOF
 	else fmt --width=${COLUMNS:-$(tput cols)} 1>&2 <<-EOF
@@ -45,14 +47,17 @@ setup_nodesource() {
 
 case "$1" in
 install|upgrade)
+	# Fix to ensure installed prerequisite 'nodejs' may be invoked as 'node'
+	update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
+
 	# Normally, dependency checking (package + minimum required version) is
 	# performed by `control' script and not in this preinstallation phase.
 	# However, the way up-to-date versions of node.js may be installed is a
 	# little bit "tricky": we let `control' require any (older) node version
 	# and here we prepare NodeSource repo configuration for a next `apt-get'
 	# command (cannot be run here due to locking of apt-related files)
-	NODE_CUR_VERSION=$(node -pe 'process.versions.node')
-	if ! valid_version $NODE_CUR_VERSION $NODE_REQ_VERSION; then
+	NODE_CUR_VERSION=$(node -pe 'process.versions.node' 2>/dev/null)
+	if ! valid_version ${NODE_CUR_VERSION:-0.0.0} $NODE_REQ_VERSION; then
 		setup_nodesource
 		exit 1
 	fi

--- a/ngsi_adapter/tools/build/files/redhat/SOURCES/etc/init.d/ngsi_adapter
+++ b/ngsi_adapter/tools/build/files/redhat/SOURCES/etc/init.d/ngsi_adapter
@@ -1,5 +1,4 @@
-#!/bin/sh
-set -a
+#!/bin/sh -a
 
 ### BEGIN INIT INFO
 # Provides:          ngsi_adapter


### PR DESCRIPTION
#### Reviewers
@jesuspg 

#### Description
Add support to install newer versions of node.js (4.x and 6.x) using NodeSource `setup` script.

#### Testing
Verified both in CentOs and Ubuntu.